### PR TITLE
Add config toggle for Create Shop chat messages

### DIFF
--- a/src/main/java/com/thesettler_x_create/Config.java
+++ b/src/main/java/com/thesettler_x_create/Config.java
@@ -85,6 +85,9 @@ public class Config {
           .comment("Cooldown (ticks) between pending delivery debug logs.")
           .defineInRange("tickPendingDebugCooldown", 200L, 0L, 24000L);
 
+  public static final ModConfigSpec.BooleanValue CHAT_MESSAGES_ENABLED =
+      BUILDER.comment("Enable Create Shop chat messages.").define("chatMessagesEnabled", true);
+
   public static final ModConfigSpec.LongValue PERF_LOG_COOLDOWN =
       BUILDER
           .comment("Cooldown (ticks) between performance timing summaries.")

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -460,6 +460,9 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   }
 
   public void notifyMissingNetwork() {
+    if (!Config.CHAT_MESSAGES_ENABLED.getAsBoolean()) {
+      return;
+    }
     TileEntityCreateShop shop = getCreateShopTileEntity();
     if (shop == null || shop.getLevel() == null) {
       return;

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -965,6 +965,9 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
   }
 
   private void sendShopChat(IRequestManager manager, String key, List<ItemStack> stacks) {
+    if (!Config.CHAT_MESSAGES_ENABLED.getAsBoolean()) {
+      return;
+    }
     if (manager == null || manager.getColony() == null) {
       return;
     }


### PR DESCRIPTION
This PR makes Create Shop chat messages optional via config.

Changes:
- Add config flag `chatMessagesEnabled` (default true)
- Gate Create Shop delivery/status chat messages
- Gate "missing network" chat warning

Notes:
- No behavior change when the config remains enabled.