### PR TITLE
Fix hut inventory button opening Create Shop address menu

### DIFF
--- a/src/main/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShop.java
@@ -9,7 +9,6 @@ import com.minecolonies.api.util.Tuple;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.core.tileentities.TileEntityRack;
 import com.thesettler_x_create.init.ModBlockEntities;
-import com.thesettler_x_create.menu.CreateShopMenu;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -81,7 +80,7 @@ public class TileEntityCreateShop extends AbstractTileEntityWareHouse {
 
   @Override
   public AbstractContainerMenu createMenu(int id, Inventory playerInventory, Player player) {
-    return new CreateShopMenu(id, playerInventory, this);
+    return super.createMenu(id, playerInventory, player);
   }
 
   @Override


### PR DESCRIPTION
Summary
• Use default MineColonies hut inventory menu for Create Shop.
Why
• The hut inventory button should open the standard hut inventory, not the Create Shop address input (which is already available via the side tabs).
Changes
• Revert TileEntityCreateShop#createMenu to super.createMenu(...) so MineColonies handles the inventory menu.