### PR TITLE
Hide Create Shop output tab in hut UI

### DIFF
--- a/src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopOutputModuleView.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopOutputModuleView.java
@@ -30,6 +30,11 @@ public class CreateShopOutputModuleView extends AbstractBuildingModuleView {
   }
 
   @Override
+  public boolean isPageVisible() {
+    return false;
+  }
+
+  @Override
   public String getIcon() {
     return "settings";
   }


### PR DESCRIPTION
Summary
• Hide the Create Shop output module tab to prevent UI shrink and avoid exposing a non‑player tab.
Changes
• CreateShopOutputModuleView#isPageVisible() now returns false.