### PR TITLE
Clarify Create Shop address routing in hut UI

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -18,3 +18,5 @@ Implementation notes:
 - This codebase intentionally uses MineColonies standard hut windows and modules where possible to
   reduce maintenance and keep UI behavior consistent with upstream.
 - Public API usage and platform constraints explain most structural similarity with other integrations.
+- UX copy and configuration guidance are written specifically for this mod (for example, in-hut
+  address panel descriptions that clarify expected routing behavior).

--- a/src/main/resources/assets/thesettler_x_create/gui/layouthuts/layoutcreateshop_address.xml
+++ b/src/main/resources/assets/thesettler_x_create/gui/layouthuts/layoutcreateshop_address.xml
@@ -7,6 +7,8 @@
           label="$(com.thesettler_x_create.gui.createshop.address_label)"/>
     <input id="addressInput" size="150 18" pos="20 46" maxlength="64"/>
 
-    <button label="$(com.thesettler_x_create.gui.createshop.save)" id="save" size="86 17" pos="52 72"
+    <text id="addressInfo" size="150 48" pos="20 72" textalign="MIDDLE_LEFT" color="black"
+          label="$(com.thesettler_x_create.gui.createshop.address_info)"/>
+    <button label="$(com.thesettler_x_create.gui.createshop.save)" id="save" size="86 17" pos="52 126"
             source="minecolonies:textures/gui/builderhut/builder_button_medium.png" color="black"/>
 </window>

--- a/src/main/resources/assets/thesettler_x_create/lang/de_de.json
+++ b/src/main/resources/assets/thesettler_x_create/lang/de_de.json
@@ -14,5 +14,8 @@
   "com.thesettler_x_create.gui.createshop.perma.empty": "No ore tags found.",
   "com.thesettler_x_create.gui.createshop.output": "Create Shop - Output",
   "com.thesettler_x_create.gui.createshop.output.linked": "Output block linked: %s",
-  "com.thesettler_x_create.gui.createshop.output.missing": "No output block linked."
+  "com.thesettler_x_create.gui.createshop.output.missing": "No output block linked.",
+  "com.thesettler_x_create.gui.createshop.address_label": "Shop-Adresse",
+  "com.thesettler_x_create.gui.createshop.address_info": "Die Adresse muss zum Shop gehoeren.\nPakete aus dem Stock-Network werden an diese Adresse geroutet.",
+  "com.thesettler_x_create.gui.createshop.save": "Speichern"
 }

--- a/src/main/resources/assets/thesettler_x_create/lang/en_us.json
+++ b/src/main/resources/assets/thesettler_x_create/lang/en_us.json
@@ -33,6 +33,7 @@
   "com.thesettler_x_create.gui.createshop.output.linked": "Output block linked: %s",
   "com.thesettler_x_create.gui.createshop.output.missing": "No output block linked.",
   "com.thesettler_x_create.gui.createshop.address_label": "Shop Address",
+  "com.thesettler_x_create.gui.createshop.address_info": "Address must belong to this shop.\nPackages from the stock network are routed to this address.",
   "com.thesettler_x_create.gui.createshop.save": "Save",
   "com.thesettler_x_create.gui.createshop.amount": "Amount",
   "com.thesettler_x_create.gui.createshop.request": "Request",


### PR DESCRIPTION
• Add an info line to the Create Shop Address panel explaining that the address must belong to the shop and that stock network packages are routed to it.
• Adjust layout to avoid text clipping.
• Document the UX guidance addition in docs/provenance.md.
Changes
• src/main/resources/assets/thesettler_x_create/gui/layouthuts/layoutcreateshop_address.xml
• src/main/resources/assets/thesettler_x_create/lang/en_us.json
• src/main/resources/assets/thesettler_x_create/lang/de_de.json
• docs/provenance.md
Notes
No functional behavior changes; UI guidance only