### PR TITLE
Add Javadoc for Create Shop APIs

### DIFF
--- a/src/main/java/com/thesettler_x_create/blockentity/CreateShopBlockEntity.java
+++ b/src/main/java/com/thesettler_x_create/blockentity/CreateShopBlockEntity.java
@@ -22,6 +22,7 @@ import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/** Pickup block entity for the Create Shop. Tracks reservations and inflight stock orders. */
 public class CreateShopBlockEntity extends BlockEntity {
   private static final String TAG_SHOP_POS = "ShopPos";
   private static final String TAG_RESERVATIONS = "Reservations";
@@ -62,6 +63,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     return null;
   }
 
+  /** Reserve items for a specific request to avoid duplicate ordering. */
   public void reserve(UUID requestId, ItemStack key, int amount) {
     if (amount <= 0) {
       return;
@@ -83,6 +85,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     setChanged();
   }
 
+  /** Release all reservations for a request. */
   public void release(UUID requestId) {
     cleanExpired();
     if (reservations.remove(requestId) != null) {
@@ -90,6 +93,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     }
   }
 
+  /** Returns total reserved count for a stack key. */
   public int getReservedFor(ItemStack key) {
     cleanExpired();
     int total = 0;
@@ -101,6 +105,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     return total;
   }
 
+  /** Returns total reserved count for a deliverable match. */
   public int getReservedForDeliverable(IDeliverable deliverable) {
     if (deliverable == null) {
       return 0;
@@ -115,6 +120,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     return total;
   }
 
+  /** Returns reserved count for a specific request. */
   public int getReservedForRequest(UUID requestId) {
     if (requestId == null) {
       return 0;
@@ -129,6 +135,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     return total;
   }
 
+  /** Consumes reserved items for a request when deliveries are created. */
   public int consumeReservedForRequest(UUID requestId, ItemStack key, int amount) {
     if (requestId == null || key == null || key.isEmpty() || amount <= 0) {
       return 0;
@@ -149,6 +156,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     return taken;
   }
 
+  /** Returns unique stack keys currently tracked as inflight. */
   public List<ItemStack> getInflightKeys() {
     List<ItemStack> keys = new ArrayList<>();
     for (InflightEntry entry : inflightEntries) {
@@ -162,6 +170,11 @@ public class CreateShopBlockEntity extends BlockEntity {
     return keys;
   }
 
+  /**
+   * Records inflight orders and their baseline stock counts.
+   *
+   * @param baselines current rack counts to detect arrivals later
+   */
   public void recordInflight(
       List<ItemStack> stacks,
       Map<ItemStack, Integer> baselines,
@@ -189,6 +202,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     }
   }
 
+  /** Reconciles inflight entries against current rack counts to detect arrivals. */
   public void reconcileInflight(Map<ItemStack, Integer> currentCounts) {
     if (inflightEntries.isEmpty()) {
       return;
@@ -235,6 +249,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     }
   }
 
+  /** Marks overdue inflight entries as notified and returns notices to surface. */
   public List<InflightNotice> consumeOverdueNotices(long now, long timeout) {
     if (timeout <= 0L || inflightEntries.isEmpty()) {
       return java.util.Collections.emptyList();

--- a/src/main/java/com/thesettler_x_create/create/ICreateNetworkFacade.java
+++ b/src/main/java/com/thesettler_x_create/create/ICreateNetworkFacade.java
@@ -4,16 +4,27 @@ import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import java.util.List;
 import net.minecraft.world.item.ItemStack;
 
+/** Abstraction for querying and ordering items from a Create stock network. */
 public interface ICreateNetworkFacade {
+  /** Returns total matching items available in the stock network. */
   int getAvailable(IDeliverable deliverable);
 
+  /** Returns available count for a specific stack signature. */
   int getAvailable(ItemStack stack);
 
+  /** Returns a snapshot list of available stacks in the network. */
   List<ItemStack> getAvailableStacks();
 
+  /** Returns an extracted stack preview (no network mutation yet). */
   ItemStack extract(ItemStack stack, int amount, boolean simulate);
 
+  /** Plans the network order stacks needed to satisfy a deliverable amount. */
   List<ItemStack> planItems(IDeliverable deliverable, int amount);
 
+  /**
+   * Broadcasts a stock network order and returns the ordered stacks.
+   *
+   * @param requesterName display name used for inflight tracking/notifications
+   */
   List<ItemStack> requestItems(IDeliverable deliverable, int amount, String requesterName);
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -615,6 +615,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     }
   }
 
+  /** Returns rack inventory counts for the given stack keys. */
   public java.util.Map<ItemStack, Integer> getStockCountsForKeys(List<ItemStack> keys) {
     java.util.Map<ItemStack, Integer> counts = new java.util.HashMap<>();
     if (keys == null || keys.isEmpty()) {
@@ -697,6 +698,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return copy;
   }
 
+  /** Periodically reconciles inflight stock orders and notifies on overdue entries. */
   private void tickInflightTracking(IColony colony) {
     if (colony == null) {
       return;
@@ -729,6 +731,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     }
   }
 
+  /** Emits a shopkeeper interaction for each overdue inflight notice. */
   private void notifyShopkeeperOverdue(List<CreateShopBlockEntity.InflightNotice> notices) {
     if (notices == null || notices.isEmpty()) {
       return;
@@ -763,6 +766,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     }
   }
 
+  /** Returns the assigned Create Shop worker, if any. */
   private ICitizenData getShopkeeperCitizen() {
     for (ICitizenData citizen : getAllAssignedCitizen()) {
       if (citizen == null) {


### PR DESCRIPTION
Summary
• Add concise Javadoc for public Create Shop APIs and inflight tracking helpers.
• Clarify intent, side effects, and usage for core interfaces and entry points.
Scope
• CreateShopBlockEntity
• ICreateNetworkFacade
• BuildingCreateShop