### PR TITLE
fix(requests): avoid unknown resolver token assignments in REQUESTABLE list

### DIFF
--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/CreateShopResolverInjector.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/CreateShopResolverInjector.java
@@ -150,9 +150,19 @@ public final class CreateShopResolverInjector {
       var deliveryResolverToken = shop.getDeliveryResolverTokenPublic();
       if (deliveryResolverToken != null) {
         if (shopHasDeliveryman(shop)) {
-          if (!requestableList.contains(deliveryResolverToken)) {
+          boolean deliveryResolverRegistered = true;
+          try {
+            resolverHandler.getResolver(deliveryResolverToken);
+          } catch (IllegalArgumentException ignored) {
+            deliveryResolverRegistered = false;
+          }
+          if (deliveryResolverRegistered && !requestableList.contains(deliveryResolverToken)) {
             requestableList.add(deliveryResolverToken);
             injected++;
+          } else if (!deliveryResolverRegistered && allowDebugLog) {
+            TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] skip REQUESTABLE add for unregistered delivery resolver {}",
+                deliveryResolverToken);
           }
         } else {
           disabledDeliveryResolvers.add(deliveryResolverToken);


### PR DESCRIPTION
## Summary
This PR fixes a request-system warning/error where MineColonies tries to assign a request to a resolver token that is not registered in the current manager.

## Problem
We observed repeated runtime errors like:

`The given token for a resolver is not known to this manager!`

This happened during request assignment when a delivery resolver token was present in `REQUESTABLE`, but the corresponding resolver was not yet registered.

## Root Cause
`CreateShopResolverInjector` could add a shop delivery resolver token to the `REQUESTABLE` assignment list based on local shop state only, without verifying registration in `resolverHandler`.

## Fix
In `CreateShopResolverInjector`:
- Before adding `deliveryResolverToken` to `REQUESTABLE`, verify that `resolverHandler.getResolver(token)` succeeds.
- If the resolver is not registered, skip the assignment entry for that tick (with debug log when enabled).

## Result
- No invalid resolver tokens are injected into the `REQUESTABLE` list.
- Request assignment no longer fails on unknown resolver tokens in this flow.