### PR TITLE
Fix Create-Shop delivery child drift: defer mixed-source child creation and consume reservations on delivery completion

### DIFF
--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -84,6 +84,10 @@ Current behavior:
   stale persists after the recheck window, reducing one-tick false-positive churn.
 - Stale/extra-child recovery revalidates live MineColonies ownership before mutation; cancel/remove/
   requeue only runs when the parent request is still owned by the local Create Shop resolver.
+- Delivery-child locality now accepts both pickup-block starts and registered shop container/rack
+  starts, so rack-sourced native MineColonies deliveries are no longer misclassified as foreign.
+- Parent pending reconciliation now removes terminal delivery children before locality gating, so
+  completed/cancelled child tokens cannot keep parent requests stuck in `IN_PROGRESS`.
 - Lost-package recovery flow is now one-shot and rack-oriented: `Reorder` no longer stays blocked
   by strict inflight tuple cleanup, `Handover` inserts unpacked contents into rack flow (no hut
   fallback), and inflight cleanup now has a stack-key fallback when requester/address text drifts.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -128,6 +128,9 @@ Current behavior:
 - Mixed-source (rack + network) request handling now defers delivery-child creation from
   `attemptResolve` to `tickPending`, so MineColonies courier pickup is only scheduled after
   rack-side availability/reconciliation on the pending path.
+- Reservation consumption timing is now delivery-completion based for local Create Shop delivery
+  starts (pickup or registered rack containers), so rack housekeeping no longer pulls items into
+  hut inventory before MineColonies delivery children have actually completed pickup/transport.
 
 Known focus area:
 - Live-world validation for long-running colonies under resolver-token drift and worker status churn.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -125,6 +125,9 @@ Current behavior:
 - Flow-step chat lines are now independently configurable and default to disabled
   (`flowChatMessagesEnabled=false`), while player-facing Create Shop chat keeps a single concise
   message per stage (order and delivery-start) to avoid duplicate/near-duplicate chat spam.
+- Mixed-source (rack + network) request handling now defers delivery-child creation from
+  `attemptResolve` to `tickPending`, so MineColonies courier pickup is only scheduled after
+  rack-side availability/reconciliation on the pending path.
 
 Known focus area:
 - Live-world validation for long-running colonies under resolver-token drift and worker status churn.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -138,6 +138,11 @@ Implementation notes:
   Shop delivery dispatch no longer injects requests directly into deliveryman jobs and now relies
   on MineColonies warehouse queue dispatch only, with queue deduplication to avoid repeated
   token insertion.
+- Delivery-child locality completion hardening on branch `fix/delivery-child-locality-completion`
+  (2026-03-09) is authored in this project: pending reconciliation now removes terminal
+  delivery children before locality gating, and locality checks accept both pickup-block starts and
+  registered shop container/rack starts, preventing false `non-local delivery child` stalls for
+  rack-sourced MineColonies native deliveries.
 - Resolver followup behavior alignment on the strict branch is authored in this project:
   Create Shop resolver followup completion now returns `null` (no explicit followups), matching
   MineColonies delivery-resolver semantics while avoiding unsafe warehouse-tile casts.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -376,3 +376,8 @@ Implementation notes:
 - Diagnostics decoupling hardening is authored in this project scope:
   `ShopCourierDiagnostics` no longer executes courier-module assignment comparison paths tied to
   `CourierAssignmentModule`, aligning diagnostics with shop-courier module removal.
+- Network-arrival child-creation gating on branch `fix/delivery-child-locality-completion`
+  (2026-03-09) is authored in this project scope: `attemptResolve` now defers delivery-child
+  creation whenever any request portion is ordered from the Create network, keeping child creation
+  in `tickPending` after rack-side arrival/reservation reconciliation instead of creating mixed
+  rack/network child sets in the initial resolve pass.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -381,3 +381,8 @@ Implementation notes:
   creation whenever any request portion is ordered from the Create network, keeping child creation
   in `tickPending` after rack-side arrival/reservation reconciliation instead of creating mixed
   rack/network child sets in the initial resolve pass.
+- Reservation lifecycle ordering hardening on branch `fix/delivery-child-locality-completion`
+  (2026-03-09) is authored in this project scope: Create Shop no longer consumes request
+  reservations at delivery-child creation time; reservation consumption is now tied to delivery
+  completion for local shop starts (pickup/rack containers), preventing housekeeping from treating
+  still-delivery-bound rack stock as unreserved.

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -1042,6 +1042,17 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         }
       }
     }
+    // Ownership is authoritative for pending processing; prefer it when drift is detected.
+    CreateShopRequestResolver ownershipSelected = findResolverFromRequestOwnership(manager);
+    if (ownershipSelected != null && (selected == null || !selected.getId().equals(ownershipSelected.getId()))) {
+      if (isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] resolver ownership priority switch {} -> {}",
+            selected == null ? "<null>" : selected.getId(),
+            ownershipSelected.getId());
+      }
+      selected = ownershipSelected;
+    }
     if (selected == null) {
       return current;
     }
@@ -1086,6 +1097,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     if (assignments == null || assignments.isEmpty()) {
       return null;
     }
+    java.util.Map<IToken<?>, Integer> ownershipCounts = new java.util.HashMap<>();
+    java.util.Map<IToken<?>, CreateShopRequestResolver> resolversById = new java.util.HashMap<>();
     for (java.util.Collection<IToken<?>> requestTokens : assignments.values()) {
       if (requestTokens == null || requestTokens.isEmpty()) {
         continue;
@@ -1098,14 +1111,27 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
           }
           IRequestResolver<?> owner = manager.getResolverHandler().getResolverForRequest(request);
           if (owner instanceof CreateShopRequestResolver shop && isLocalShopResolver(shop)) {
-            return shop;
+            IToken<?> ownerId = shop.getId();
+            ownershipCounts.merge(ownerId, 1, Integer::sum);
+            resolversById.putIfAbsent(ownerId, shop);
           }
         } catch (Exception ignored) {
           // Ignore stale request/resolver links.
         }
       }
     }
-    return null;
+    if (ownershipCounts.isEmpty()) {
+      return null;
+    }
+    IToken<?> dominantOwner = null;
+    int dominantCount = 0;
+    for (var entry : ownershipCounts.entrySet()) {
+      if (entry.getValue() > dominantCount) {
+        dominantOwner = entry.getKey();
+        dominantCount = entry.getValue();
+      }
+    }
+    return dominantOwner == null ? null : resolversById.get(dominantOwner);
   }
 
   @Nullable

--- a/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
@@ -1,54 +1,276 @@
 package com.thesettler_x_create.minecolonies.command;
 
+import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.IColonyManager;
+import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.Stack;
+import com.minecolonies.api.colony.requestsystem.requester.IRequester;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.thesettler_x_create.TheSettlerXCreate;
+import com.thesettler_x_create.create.CreateNetworkFacade;
 import com.thesettler_x_create.minecolonies.building.BuildingCreateShop;
 import com.thesettler_x_create.minecolonies.requestsystem.resolver.CreateShopRequestResolver;
+import com.thesettler_x_create.minecolonies.tileentity.TileEntityCreateShop;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
 
 /** Server commands for Create Shop maintenance and uninstall preparation. */
 public final class CreateShopMaintenanceCommands {
   private CreateShopMaintenanceCommands() {}
 
   public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-    dispatcher.register(
-        Commands.literal("thesettlerxcreate")
-            .requires(source -> source.hasPermission(2))
+    var root = Commands.literal("thesettlerxcreate").requires(source -> source.hasPermission(2));
+
+    root.then(
+        Commands.literal("prepare_uninstall")
+            .executes(
+                context -> {
+                  Result result = prepareUninstall();
+                  context
+                      .getSource()
+                      .sendSuccess(
+                          () ->
+                              Component.literal(
+                                  "[CreateShop] Uninstall prepare complete: colonies="
+                                      + result.colonies
+                                      + ", shops="
+                                      + result.shops
+                                      + ", providerUnregister="
+                                      + result.providerUnregister
+                                      + ", requestsCancelled="
+                                      + result.requestsCancelled
+                                      + ", errors="
+                                      + result.errors),
+                          true);
+                  context
+                      .getSource()
+                      .sendSuccess(
+                          () ->
+                              Component.literal(
+                                  "[CreateShop] Next step: stop server, backup world, remove mod jar, then restart."),
+                          false);
+                  return result.errors == 0 ? 1 : 0;
+                }));
+
+    root.then(
+        Commands.literal("run_live_test")
+            .executes(context -> runLiveTest(context.getSource(), 8, 8))
             .then(
-                Commands.literal("prepare_uninstall")
+                Commands.argument("requests", IntegerArgumentType.integer(1, 256))
                     .executes(
-                        context -> {
-                          Result result = prepareUninstall();
-                          context
-                              .getSource()
-                              .sendSuccess(
-                                  () ->
-                                      Component.literal(
-                                          "[CreateShop] Uninstall prepare complete: colonies="
-                                              + result.colonies
-                                              + ", shops="
-                                              + result.shops
-                                              + ", providerUnregister="
-                                              + result.providerUnregister
-                                              + ", requestsCancelled="
-                                              + result.requestsCancelled
-                                              + ", errors="
-                                              + result.errors),
-                                  true);
-                          context
-                              .getSource()
-                              .sendSuccess(
-                                  () ->
-                                      Component.literal(
-                                          "[CreateShop] Next step: stop server, backup world, remove mod jar, then restart."),
-                                  false);
-                          return result.errors == 0 ? 1 : 0;
-                        })));
+                        context ->
+                            runLiveTest(
+                                context.getSource(),
+                                IntegerArgumentType.getInteger(context, "requests"),
+                                8))
+                    .then(
+                        Commands.argument("amount", IntegerArgumentType.integer(1, 64))
+                            .executes(
+                                context ->
+                                    runLiveTest(
+                                        context.getSource(),
+                                        IntegerArgumentType.getInteger(context, "requests"),
+                                        IntegerArgumentType.getInteger(context, "amount"))))));
+
+    dispatcher.register(root);
+  }
+
+  private static int runLiveTest(CommandSourceStack source, int requests, int amount) {
+    LiveTestResult result = runLiveTest(requests, amount);
+    source.sendSuccess(
+        () ->
+            Component.literal(
+                "[CreateShop] Live test: requested="
+                    + requests
+                    + ", amount="
+                    + amount
+                    + ", created="
+                    + result.created
+                    + ", errors="
+                    + result.errors
+                    + ", colonies="
+                    + result.colonies
+                    + ", shopsSeen="
+                    + result.shopsSeen),
+        true);
+    if (!result.message.isEmpty()) {
+      source.sendSuccess(() -> Component.literal("[CreateShop] " + result.message), false);
+    }
+    return result.created > 0 ? 1 : 0;
+  }
+
+  private static LiveTestResult runLiveTest(int requests, int amount) {
+    LiveTestResult result = new LiveTestResult();
+    int requestCount = Math.max(1, requests);
+    int stackAmount = Math.max(1, amount);
+
+    for (IColony colony : IColonyManager.getInstance().getAllColonies()) {
+      result.colonies++;
+      if (!(colony.getRequestManager() instanceof IStandardRequestManager standard)) {
+        continue;
+      }
+      var buildingManager = colony.getServerBuildingManager();
+      if (buildingManager == null || buildingManager.getBuildings() == null) {
+        continue;
+      }
+
+      for (var entry : buildingManager.getBuildings().entrySet()) {
+        var building = entry.getValue();
+        if (!(building instanceof BuildingCreateShop shop)) {
+          continue;
+        }
+        result.shopsSeen++;
+        TileEntityCreateShop tile = shop.getCreateShopTileEntity();
+        if (tile == null || tile.getStockNetworkId() == null) {
+          continue;
+        }
+
+        ItemStack available = selectLiveTestStack(tile);
+        if (available.isEmpty()) {
+          continue;
+        }
+
+        IRequester target = findLiveTestTargetRequester(colony, shop);
+        if (target == null) {
+          result.message =
+              "No valid target requester found for shop at "
+                  + shop.getLocation().getInDimensionLocation();
+          continue;
+        }
+
+        int singleRequestAmount = Math.max(1, Math.min(stackAmount, available.getMaxStackSize()));
+        int localCreated = 0;
+        for (int i = 0; i < requestCount; i++) {
+          try {
+            ItemStack requestStack = available.copy();
+            requestStack.setCount(singleRequestAmount);
+            IToken<?> token = standard.createRequest(target, new Stack(requestStack));
+            standard.assignRequest(token);
+            localCreated++;
+            result.created++;
+            TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] run_live_test created request token={} shop={} target={} item={} count={}",
+                token,
+                shop.getLocation().getInDimensionLocation(),
+                target.getLocation().getInDimensionLocation(),
+                requestStack.getItem(),
+                requestStack.getCount());
+          } catch (Exception ex) {
+            result.errors++;
+            TheSettlerXCreate.LOGGER.warn(
+                "[CreateShop] run_live_test createRequest failed shop={} error={}",
+                shop.getLocation().getInDimensionLocation(),
+                ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+          }
+        }
+
+        result.message =
+            "Shop="
+                + shop.getLocation().getInDimensionLocation()
+                + " target="
+                + target.getLocation().getInDimensionLocation()
+                + " item="
+                + available.getHoverName().getString()
+                + " perRequest="
+                + singleRequestAmount
+                + " created="
+                + localCreated;
+
+        if (localCreated > 0) {
+          return result;
+        }
+      }
+    }
+
+    if (result.message.isEmpty()) {
+      result.message =
+          "No eligible Create Shop with network stock and valid target requester found.";
+    }
+    return result;
+  }
+
+  private static ItemStack selectLiveTestStack(TileEntityCreateShop tile) {
+    if (tile == null || tile.getStockNetworkId() == null) {
+      return ItemStack.EMPTY;
+    }
+    java.util.List<ItemStack> available = new CreateNetworkFacade(tile).getAvailableStacks();
+    if (available == null || available.isEmpty()) {
+      return ItemStack.EMPTY;
+    }
+
+    ItemStack best = ItemStack.EMPTY;
+    int bestCount = 0;
+    for (ItemStack stack : available) {
+      if (stack == null || stack.isEmpty() || stack.getCount() <= 0) {
+        continue;
+      }
+      if (stack.getCount() > bestCount) {
+        best = stack.copy();
+        bestCount = stack.getCount();
+      }
+    }
+    return best;
+  }
+
+  private static IRequester findLiveTestTargetRequester(IColony colony, BuildingCreateShop shop) {
+    if (colony == null || shop == null) {
+      return null;
+    }
+    var buildingManager = colony.getServerBuildingManager();
+    if (buildingManager == null || buildingManager.getBuildings() == null) {
+      return null;
+    }
+
+    BlockPos shopPos = shop.getLocation().getInDimensionLocation();
+    IRequester best = null;
+    int bestTier = Integer.MAX_VALUE;
+    double bestDistance = Double.MAX_VALUE;
+
+    for (var entry : buildingManager.getBuildings().entrySet()) {
+      var candidate = entry.getValue();
+      if (!(candidate instanceof AbstractBuilding building)
+          || candidate instanceof BuildingCreateShop) {
+        continue;
+      }
+      IRequester requester = building.getRequester();
+      if (requester == null || requester.getLocation() == null) {
+        continue;
+      }
+      if (!requester.getLocation().getDimension().equals(shop.getLocation().getDimension())) {
+        continue;
+      }
+      BlockPos targetPos = requester.getLocation().getInDimensionLocation();
+      if (targetPos == null || targetPos.equals(shopPos)) {
+        continue;
+      }
+      int tier = targetPriorityTier(candidate);
+      double distance = targetPos.distSqr(shopPos);
+      if (tier < bestTier || (tier == bestTier && distance < bestDistance)) {
+        best = requester;
+        bestTier = tier;
+        bestDistance = distance;
+      }
+    }
+
+    return best;
+  }
+
+  private static int targetPriorityTier(Object building) {
+    if (building instanceof IWareHouse && !(building instanceof BuildingCreateShop)) {
+      return 0; // Warehouse first.
+    }
+    if (building != null && "PostBox".equals(building.getClass().getSimpleName())) {
+      return 1; // Then PostBox.
+    }
+    return 2; // Finally any other requester building.
   }
 
   private static Result prepareUninstall() {
@@ -122,5 +344,13 @@ public final class CreateShopMaintenanceCommands {
     int providerUnregister;
     int requestsCancelled;
     int errors;
+  }
+
+  private static final class LiveTestResult {
+    int colonies;
+    int shopsSeen;
+    int created;
+    int errors;
+    String message = "";
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -632,6 +632,28 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
                   && child.getRequest()
                       instanceof
                       com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery) {
+                var childState = child.getState();
+                boolean terminalChild =
+                    childState
+                            == com.minecolonies.api.colony.requestsystem.request.RequestState
+                                .COMPLETED
+                        || childState
+                            == com.minecolonies.api.colony.requestsystem.request.RequestState
+                                .CANCELLED
+                        || childState
+                            == com.minecolonies.api.colony.requestsystem.request.RequestState.FAILED
+                        || childState
+                            == com.minecolonies.api.colony.requestsystem.request.RequestState
+                                .RESOLVED
+                        || childState
+                            == com.minecolonies.api.colony.requestsystem.request.RequestState
+                                .RECEIVED;
+                if (terminalChild) {
+                  request.removeChild(childToken);
+                  deliveryChildActiveSince.remove(childToken);
+                  clearStaleRecoveryArm(request.getId());
+                  continue;
+                }
                 if (!isLocalShopDeliveryChild(child, shop, pickup)) {
                   hasActiveChildren = true;
                   if (Config.DEBUG_LOGGING.getAsBoolean()) {
@@ -672,56 +694,34 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
                         enqueued ? "ok" : "none");
                   }
                 }
-                var childState = child.getState();
-                boolean terminalChild =
-                    childState
-                            == com.minecolonies.api.colony.requestsystem.request.RequestState
-                                .COMPLETED
-                        || childState
-                            == com.minecolonies.api.colony.requestsystem.request.RequestState
-                                .CANCELLED
-                        || childState
-                            == com.minecolonies.api.colony.requestsystem.request.RequestState.FAILED
-                        || childState
-                            == com.minecolonies.api.colony.requestsystem.request.RequestState
-                                .RESOLVED
-                        || childState
-                            == com.minecolonies.api.colony.requestsystem.request.RequestState
-                                .RECEIVED;
-                if (terminalChild) {
-                  request.removeChild(childToken);
-                  deliveryChildActiveSince.remove(childToken);
-                  clearStaleRecoveryArm(request.getId());
+                if (activeLocalDeliveryChild != null
+                    && !activeLocalDeliveryChild.equals(childToken)) {
+                  boolean recovered =
+                      recoverExtraActiveDeliveryChild(
+                          standardManager, level, request, childToken, child, shop, pickup);
+                  if (recovered) {
+                    missing++;
+                    continue;
+                  }
                 } else {
-                  if (activeLocalDeliveryChild != null
-                      && !activeLocalDeliveryChild.equals(childToken)) {
-                    boolean recovered =
-                        recoverExtraActiveDeliveryChild(
-                            standardManager, level, request, childToken, child, shop, pickup);
-                    if (recovered) {
-                      missing++;
-                      continue;
-                    }
-                  } else {
-                    activeLocalDeliveryChild = childToken;
-                  }
-                  if (isStaleDeliveryChild(level, request.getId(), childToken, childState)) {
-                    if (!isStaleRecoveryArmed(level, standardManager, request.getId())) {
-                      hasActiveChildren = true;
-                      continue;
-                    }
-                    boolean recovered =
-                        recoverStaleDeliveryChild(
-                            standardManager, level, request, childToken, child, shop, pickup);
-                    if (recovered) {
-                      missing++;
-                      continue;
-                    }
-                  } else {
-                    clearStaleRecoveryArm(request.getId());
-                  }
-                  hasActiveChildren = true;
+                  activeLocalDeliveryChild = childToken;
                 }
+                if (isStaleDeliveryChild(level, request.getId(), childToken, childState)) {
+                  if (!isStaleRecoveryArmed(level, standardManager, request.getId())) {
+                    hasActiveChildren = true;
+                    continue;
+                  }
+                  boolean recovered =
+                      recoverStaleDeliveryChild(
+                          standardManager, level, request, childToken, child, shop, pickup);
+                  if (recovered) {
+                    missing++;
+                    continue;
+                  }
+                } else {
+                  clearStaleRecoveryArm(request.getId());
+                }
+                hasActiveChildren = true;
               } else {
                 deliveryChildActiveSince.remove(childToken);
               }
@@ -2094,8 +2094,17 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     if (start == null || level == null || start.getDimension() == null) {
       return false;
     }
-    return level.dimension().equals(start.getDimension())
-        && pickup.getBlockPos().equals(start.getInDimensionLocation());
+    if (!level.dimension().equals(start.getDimension())) {
+      return false;
+    }
+    BlockPos startPos = start.getInDimensionLocation();
+    if (startPos == null) {
+      return false;
+    }
+    if (pickup.getBlockPos().equals(startPos)) {
+      return true;
+    }
+    return shop.hasContainerPosition(startPos);
   }
 
   private boolean isDeliveryFromPickup(Delivery delivery, CreateShopBlockEntity pickup) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -1352,53 +1352,51 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             pickup = shopPickup;
           }
         }
-        if (pickup == null || !isDeliveryFromLocalShopStart(delivery, shop, pickup)) {
-          return;
+        if (pickup != null && isDeliveryFromLocalShopStart(delivery, shop, pickup)) {
+          UUID parentRequestId = toRequestId(parentToken);
+          ItemStack stack = delivery.getStack().copy();
+          int reservedForStackBefore = pickup.getReservedFor(stack);
+          if (!stack.isEmpty()) {
+            pickup.consumeReservedForRequest(parentRequestId, stack, stack.getCount());
+          }
+          int reservedForStackAfter = pickup.getReservedFor(stack);
+          int consumedReserved = Math.max(0, reservedForStackBefore - reservedForStackAfter);
+          if (consumedReserved > 0 && parentRequest != null) {
+            transitionFlow(
+                manager,
+                parentRequest,
+                CreateShopFlowState.RESERVED_FOR_DELIVERY,
+                "delivery-complete:reserved-consumed",
+                describeStack(stack),
+                consumedReserved,
+                "com.thesettler_x_create.message.createshop.flow_reserved");
+          }
+          if (isDebugLoggingEnabled()) {
+            int reservedForRequest = pickup.getReservedForRequest(parentRequestId);
+            int reservedForStack = reservedForStackAfter;
+            BlockPos pickupPosition = pickup.getBlockPos();
+            deliveryManager.logDeliveryDiagnostics(
+                "complete",
+                manager,
+                request.getId(),
+                parentRequestId,
+                pickupPosition,
+                stack,
+                delivery.getTarget(),
+                reservedForRequest,
+                -1,
+                reservedForStack);
+            TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] delivery complete detail token={} parent={} stack={} count={} start={} target={} reservedConsumed={}",
+                request.getId(),
+                parentToken,
+                stack.isEmpty() ? "<empty>" : stack.getItem().toString(),
+                stack.getCount(),
+                startPos,
+                delivery.getTarget().getInDimensionLocation(),
+                consumedReserved);
+          }
         }
-        UUID parentRequestId = toRequestId(parentToken);
-        ItemStack stack = delivery.getStack().copy();
-        int reservedForStackBefore = pickup.getReservedFor(stack);
-        if (!stack.isEmpty()) {
-          pickup.consumeReservedForRequest(parentRequestId, stack, stack.getCount());
-        }
-        int reservedForStackAfter = pickup.getReservedFor(stack);
-        int consumedReserved = Math.max(0, reservedForStackBefore - reservedForStackAfter);
-        if (consumedReserved > 0 && parentRequest != null) {
-          transitionFlow(
-              manager,
-              parentRequest,
-              CreateShopFlowState.RESERVED_FOR_DELIVERY,
-              "delivery-complete:reserved-consumed",
-              describeStack(stack),
-              consumedReserved,
-              "com.thesettler_x_create.message.createshop.flow_reserved");
-        }
-        if (!isDebugLoggingEnabled()) {
-          return;
-        }
-        int reservedForRequest = pickup.getReservedForRequest(parentRequestId);
-        int reservedForStack = reservedForStackAfter;
-        BlockPos pickupPosition = pickup.getBlockPos();
-        deliveryManager.logDeliveryDiagnostics(
-            "complete",
-            manager,
-            request.getId(),
-            parentRequestId,
-            pickupPosition,
-            stack,
-            delivery.getTarget(),
-            reservedForRequest,
-            -1,
-            reservedForStack);
-        TheSettlerXCreate.LOGGER.info(
-            "[CreateShop] delivery complete detail token={} parent={} stack={} count={} start={} target={} reservedConsumed={}",
-            request.getId(),
-            parentToken,
-            stack.isEmpty() ? "<empty>" : stack.getItem().toString(),
-            stack.getCount(),
-            startPos,
-            delivery.getTarget().getInDimensionLocation(),
-            consumedReserved);
       } catch (Exception ignored) {
         // Ignore delivery detail logging failures.
       }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -289,17 +289,6 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             "com.thesettler_x_create.message.createshop.flow_arrived");
         List<IToken<?>> created =
             deliveryManager.createDeliveriesFromStacks(manager, request, planned, pickup);
-        if (plannedCount > 0 && reservedForRequest > 0) {
-          consumeReservedForRequest(pickup, requestId, planned);
-          transitionFlow(
-              manager,
-              request,
-              CreateShopFlowState.RESERVED_FOR_DELIVERY,
-              "attemptResolve:reserved-consumed",
-              describeStack(ordered.get(0)),
-              plannedCount,
-              "com.thesettler_x_create.message.createshop.flow_reserved");
-        }
         if (Config.DEBUG_LOGGING.getAsBoolean()) {
           TheSettlerXCreate.LOGGER.info(
               "[CreateShop] attemptResolve created deliveries parent={} manager={} tokens={}",
@@ -1009,17 +998,6 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
           "com.thesettler_x_create.message.createshop.flow_delivery_created");
       diagnostics.logPendingReasonChange(request.getId(), "create:delivery");
       int deliveredCount = planning.countPlanned(stacks);
-      if (reservedForRequest > 0 && deliveredCount > 0) {
-        consumeReservedForRequest(pickup, requestId, stacks);
-        transitionFlow(
-            manager,
-            request,
-            CreateShopFlowState.RESERVED_FOR_DELIVERY,
-            "tickPending:reserved-consumed",
-            describeStack(ordered.isEmpty() ? ItemStack.EMPTY : ordered.get(0)),
-            deliveredCount,
-            "com.thesettler_x_create.message.createshop.flow_reserved");
-      }
       int remainingCount = Math.max(0, pendingCount - deliveredCount);
       if (remainingCount > 0) {
         pendingTracker.setPendingCount(request.getId(), remainingCount);
@@ -1282,7 +1260,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       }
       return;
     }
-    if (!isDeliveryFromPickup(delivery, pickup)) {
+    if (!isDeliveryFromLocalShopStart(delivery, shop, pickup)) {
       return;
     }
 
@@ -1354,26 +1332,52 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
           request.getRequest() instanceof Delivery d ? d.getStack().getCount() : 0,
           "com.thesettler_x_create.message.createshop.flow_delivery_completed");
     }
-    if (isDebugLoggingEnabled()
-        && request != null
-        && request.getRequest() instanceof Delivery delivery) {
+    if (request != null && request.getRequest() instanceof Delivery delivery) {
       try {
+        BuildingCreateShop shop = getShop(manager);
         CreateShopBlockEntity pickup = null;
-        Level level = manager == null ? null : manager.getColony().getWorld();
-        BlockPos startPos = delivery.getStart().getInDimensionLocation();
-        if (level != null && WorldUtil.isBlockLoaded(level, startPos)) {
+        if (shop != null) {
+          pickup = shop.getPickupBlockEntity();
+        }
+        Level level =
+            manager == null || manager.getColony() == null ? null : manager.getColony().getWorld();
+        ILocation start = delivery.getStart();
+        BlockPos startPos = start == null ? null : start.getInDimensionLocation();
+        if (pickup == null
+            && level != null
+            && startPos != null
+            && WorldUtil.isBlockLoaded(level, startPos)) {
           BlockEntity startEntity = level.getBlockEntity(startPos);
           if (startEntity instanceof CreateShopBlockEntity shopPickup) {
             pickup = shopPickup;
           }
         }
-        if (pickup == null || !isDeliveryFromPickup(delivery, pickup)) {
+        if (pickup == null || !isDeliveryFromLocalShopStart(delivery, shop, pickup)) {
           return;
         }
         UUID parentRequestId = toRequestId(parentToken);
         ItemStack stack = delivery.getStack().copy();
+        int reservedForStackBefore = pickup.getReservedFor(stack);
+        if (!stack.isEmpty()) {
+          pickup.consumeReservedForRequest(parentRequestId, stack, stack.getCount());
+        }
+        int reservedForStackAfter = pickup.getReservedFor(stack);
+        int consumedReserved = Math.max(0, reservedForStackBefore - reservedForStackAfter);
+        if (consumedReserved > 0 && parentRequest != null) {
+          transitionFlow(
+              manager,
+              parentRequest,
+              CreateShopFlowState.RESERVED_FOR_DELIVERY,
+              "delivery-complete:reserved-consumed",
+              describeStack(stack),
+              consumedReserved,
+              "com.thesettler_x_create.message.createshop.flow_reserved");
+        }
+        if (!isDebugLoggingEnabled()) {
+          return;
+        }
         int reservedForRequest = pickup.getReservedForRequest(parentRequestId);
-        int reservedForStack = pickup.getReservedFor(stack);
+        int reservedForStack = reservedForStackAfter;
         BlockPos pickupPosition = pickup.getBlockPos();
         deliveryManager.logDeliveryDiagnostics(
             "complete",
@@ -1387,13 +1391,14 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             -1,
             reservedForStack);
         TheSettlerXCreate.LOGGER.info(
-            "[CreateShop] delivery complete detail token={} parent={} stack={} count={} start={} target={}",
+            "[CreateShop] delivery complete detail token={} parent={} stack={} count={} start={} target={} reservedConsumed={}",
             request.getId(),
             parentToken,
             stack.isEmpty() ? "<empty>" : stack.getItem().toString(),
             stack.getCount(),
             startPos,
-            delivery.getTarget().getInDimensionLocation());
+            delivery.getTarget().getInDimensionLocation(),
+            consumedReserved);
       } catch (Exception ignored) {
         // Ignore delivery detail logging failures.
       }
@@ -1606,25 +1611,6 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
               cleared);
         }
       }
-    }
-  }
-
-  private void consumeReservedForRequest(
-      CreateShopBlockEntity pickup,
-      UUID requestId,
-      List<com.minecolonies.api.util.Tuple<ItemStack, BlockPos>> stacks) {
-    if (pickup == null || requestId == null || stacks == null) {
-      return;
-    }
-    for (var entry : stacks) {
-      if (entry == null) {
-        continue;
-      }
-      ItemStack stack = entry.getA();
-      if (stack == null || stack.isEmpty()) {
-        continue;
-      }
-      pickup.consumeReservedForRequest(requestId, stack, stack.getCount());
     }
   }
 
@@ -2121,6 +2107,28 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     }
     return pickup.getLevel().dimension().equals(start.getDimension())
         && pickup.getBlockPos().equals(start.getInDimensionLocation());
+  }
+
+  private boolean isDeliveryFromLocalShopStart(
+      Delivery delivery, BuildingCreateShop shop, CreateShopBlockEntity pickup) {
+    if (delivery == null || pickup == null || pickup.getLevel() == null) {
+      return false;
+    }
+    ILocation start = delivery.getStart();
+    if (start == null || start.getDimension() == null) {
+      return false;
+    }
+    if (!pickup.getLevel().dimension().equals(start.getDimension())) {
+      return false;
+    }
+    BlockPos startPos = start.getInDimensionLocation();
+    if (startPos == null) {
+      return false;
+    }
+    if (isDeliveryFromPickup(delivery, pickup)) {
+      return true;
+    }
+    return shop != null && shop.hasContainerPosition(startPos);
   }
 
   private void clearTrackedChildrenForParent(

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -246,6 +246,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
           needed,
           ordered.size());
     }
+    boolean hasNetworkPortion = remaining > 0;
     if (!ordered.isEmpty()) {
       transitionFlow(
           manager,
@@ -255,8 +256,15 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
           describeStack(ordered.get(0)),
           countStackList(ordered),
           "com.thesettler_x_create.message.createshop.flow_ordered");
-      // If we can satisfy from racks, create deliveries immediately.
-      if (rackUsable > 0) {
+      // If any portion came from the network, defer child creation to tickPending.
+      if (hasNetworkPortion) {
+        cooldown.markRequestOrdered(level, request.getId());
+        pendingTracker.setPendingCount(request.getId(), Math.max(1, needed));
+        diagnostics.recordPendingSource(request.getId(), "attemptResolve:defer-network-arrival");
+        flowStateMachine.touch(request.getId(), now, "attemptResolve:defer-network-arrival");
+        messaging.sendShopChat(
+            manager, "com.thesettler_x_create.message.createshop.request_sent", ordered);
+      } else if (rackUsable > 0) {
         if (unwrapStandardManager(manager) == null) {
           cooldown.markRequestOrdered(level, request.getId());
           pendingTracker.setPendingCount(request.getId(), Math.max(1, needed));
@@ -292,11 +300,6 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
               plannedCount,
               "com.thesettler_x_create.message.createshop.flow_reserved");
         }
-        if (remaining > 0) {
-          cooldown.markRequestOrdered(level, request.getId());
-          pendingTracker.setPendingCount(request.getId(), Math.max(1, needed - plannedCount));
-          diagnostics.recordPendingSource(request.getId(), "attemptResolve:partial");
-        }
         if (Config.DEBUG_LOGGING.getAsBoolean()) {
           TheSettlerXCreate.LOGGER.info(
               "[CreateShop] attemptResolve created deliveries parent={} manager={} tokens={}",
@@ -315,13 +318,14 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
               "com.thesettler_x_create.message.createshop.flow_delivery_created");
         }
         return created;
+      } else {
+        // Otherwise, order from network and wait for arrival.
+        cooldown.markRequestOrdered(level, request.getId());
+        pendingTracker.setPendingCount(request.getId(), needed);
+        diagnostics.recordPendingSource(request.getId(), "attemptResolve:network-ordered");
+        messaging.sendShopChat(
+            manager, "com.thesettler_x_create.message.createshop.request_sent", ordered);
       }
-      // Otherwise, order from network and wait for arrival.
-      cooldown.markRequestOrdered(level, request.getId());
-      pendingTracker.setPendingCount(request.getId(), needed);
-      diagnostics.recordPendingSource(request.getId(), "attemptResolve:network-ordered");
-      messaging.sendShopChat(
-          manager, "com.thesettler_x_create.message.createshop.request_sent", ordered);
     }
 
     // Reserve ordered items so they count as in-progress and avoid re-ordering.
@@ -334,8 +338,8 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       }
     }
 
-    // If we ordered from the network, we wait for arrival and do not create deliveries yet.
-    if (rackUsable <= 0) {
+    // If we ordered from the network, we wait for arrival and do not create deliveries here.
+    if (hasNetworkPortion || rackUsable <= 0) {
       return Lists.newArrayList();
     }
 


### PR DESCRIPTION
- Deferred mixed-source (rack + network) delivery-child creation:
  - `attemptResolve` no longer creates child deliveries when any portion is still network-ordered.
  - Mixed cases are now pushed into pending flow and child creation happens in `tickPending` after rack-side availability/reconciliation.
- Fixed reservation lifecycle ordering:
  - Removed reservation consumption at `delivery-created`.
  - Reservation consumption now happens on delivery completion.
  - Local delivery start validation now accepts both:
    - pickup block start
    - registered shop container/rack starts
- Added/kept live test command support:
  - `/thesettlerxcreate run_live_test [requests] [amount]`
  - Picks an available network item and targets (priority): Warehouse -> PostBox -> other requester buildings.

### Why
We observed state drift where items were physically present in racks but request/child state could desync:
- child deliveries created too early in mixed-source paths
- reservations consumed before actual courier completion
- housekeeping could treat still-needed rack stock as unreserved

This PR aligns timing with native MineColonies delivery lifecycle.
