### PR TITLE
fix(createshop): stabilize inflight lost-package recovery and delivery state transitions

### DIFF
--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -108,6 +108,9 @@ Current behavior:
   local Create Shop-owned requests via MineColonies request-state updates and clears matching
   inflight tuple tracking, enabling clean native re-request from colony side when recovery is
   intentionally aborted.
+- Lost-package reorder failures caused by insufficient stock-network availability now open a
+  dedicated one-button info interaction (`Back`) and then return to the lost-package options,
+  instead of silently closing without player-visible feedback.
 - Lost-package handover now pre-checks preview-accepted package content against remaining inflight
   before removing a player package, and stops further package removals after a consume-miss to
   avoid multi-package loss when tuple consumption fails.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -117,6 +117,12 @@ Current behavior:
 - Lost-package inflight consumption now falls back to same-item matching for component drift, and
   restart reorder volume is bounded by currently tracked inflight remainder for the tuple to avoid
   duplicate over-ordering after world reloads.
+- Lost-package interactions now carry a shop-local runtime epoch that is bumped during
+  `/thesettlerxcreate reset_live_state`, so stale pre-reset dialogs cannot mutate new post-reset
+  runtime state.
+- Lost-package response handling now verifies tuple liveness (`stack + requester + address + requestedAt`)
+  before processing, and stale dialogs self-invalidate instead of triggering empty reorders or
+  phantom follow-up interactions.
 - Open inflight overdue entries are now re-armed for prompting on world load (`notified=false`
   during load), so blocked/lost-package interactions can reappear after reload when still unresolved.
 - Cancelled requests now clear matching lost-package inflight entries immediately, so cancelling a

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -142,6 +142,9 @@ Known focus area:
   counters consistently (instead of always logging `notified=0`) for clearer delivery diagnostics.
 - Pending top-up now subtracts already-available rack stock before ordering from Create network,
   preventing duplicate reorders when requested quantity is already physically present in shop racks.
+- Pending top-up now hard-blocks network reorders while matching inflight stock for the same
+  request tuple is still open, preventing repeated order loops before overdue/lost-package
+  resolution.
 - Pending reconciliation now refreshes missing request reservations from currently available rack
   stock after request-state refresh, improving reload recovery when reservation maps drift or reset.
 - Shopkeeper AI now treats resolver work and unreserved incoming-rack housekeeping as urgent work,

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -104,6 +104,10 @@ Current behavior:
 - Lost-package handover now processes multiple matching player packages in one action and caps
   inflight consumption to the overdue target amount (`remaining`), preventing unnecessary extra
   package removal beyond the required recovery amount.
+- Lost-package interaction now includes a third action (`Cancel request`) that cancels matching
+  local Create Shop-owned requests via MineColonies request-state updates and clears matching
+  inflight tuple tracking, enabling clean native re-request from colony side when recovery is
+  intentionally aborted.
 - Lost-package handover now pre-checks preview-accepted package content against remaining inflight
   before removing a player package, and stops further package removals after a consume-miss to
   avoid multi-package loss when tuple consumption fails.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -366,6 +366,11 @@ Implementation notes:
 - Lost-package handover amount-limiting hardening is authored in this project scope:
   one handover action now iterates multiple matching player packages as needed but limits inflight
   consumption to the interaction target (`remaining`) so recovery does not over-consume requests.
+- Lost-package cancel-action hardening is authored in this project scope:
+  interaction response routing now supports a third action that cancels matching local Create Shop
+  requests via MineColonies `updateRequestState(..., CANCELLED)` and clears matching inflight
+  tracking for the tuple, so players can abort stuck overdue flows without forcing duplicate
+  reorders.
 - Lost-package handover consume-guard hardening is authored in this project scope:
   package removal now requires preview-accepted matching content plus remaining inflight coverage,
   and handover stops further package removals after a consume-miss to prevent multi-package loss

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -371,6 +371,10 @@ Implementation notes:
   requests via MineColonies `updateRequestState(..., CANCELLED)` and clears matching inflight
   tracking for the tuple, so players can abort stuck overdue flows without forcing duplicate
   reorders.
+- Lost-package reorder-failure feedback hardening is authored in this project scope:
+  when reorder cannot be created due to missing stock-network availability, the shopkeeper now
+  presents a dedicated one-button info interaction (`Back`) and then re-opens the lost-package
+  options, avoiding silent UI close without player feedback.
 - Lost-package handover consume-guard hardening is authored in this project scope:
   package removal now requires preview-accepted matching content plus remaining inflight coverage,
   and handover stops further package removals after a consume-miss to prevent multi-package loss

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -399,3 +399,12 @@ Implementation notes:
   reservations at delivery-child creation time; reservation consumption is now tied to delivery
   completion for local shop starts (pickup/rack containers), preventing housekeeping from treating
   still-delivery-bound rack stock as unreserved.
+- Lost-package stale-interaction invalidation hardening on branch `fix/inflight-reorder-guard`
+  (2026-03-10) is authored in this project scope: lost-package interactions now carry a
+  shop-local runtime epoch, and `reset_live_state` bumps that epoch so pre-reset dialogs cannot
+  mutate post-reset runtime state.
+- Lost-package tuple-liveness response guard hardening on branch `fix/inflight-reorder-guard`
+  (2026-03-10) is authored in this project scope: interaction responses now validate live inflight
+  remainder for the exact overdue segment (`item + requester + address + requestedAt`) before
+  reorder/handover/cancel routing, preventing stale dialog responses from re-opening flows after
+  tuple resolution.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -242,6 +242,10 @@ Implementation notes:
 - Pending top-up coverage hardening is authored in this project scope: Create Shop `tickPending`
   now subtracts rack-available stock from top-up deficit calculation before issuing Create network
   orders, preventing duplicate network reorders when enough items are already in shop racks.
+- Pending inflight reorder guard hardening is authored in this project scope: `tickPending` now
+  blocks Create-network top-up for a parent while matching inflight stock for the same
+  deliverable/requester/address tuple remains open, keeping requests in waiting state instead of
+  repeatedly reordering before overdue/lost-package handling.
 - Reservation-refresh hardening is authored in this project scope: `tickPending` now reconstructs
   missing per-request reservations from currently available rack stock after request refresh,
   reducing post-reload reservation drift and avoiding premature unreserved treatment of pending

--- a/src/main/java/com/thesettler_x_create/blockentity/CreateShopBlockEntity.java
+++ b/src/main/java/com/thesettler_x_create/blockentity/CreateShopBlockEntity.java
@@ -322,6 +322,15 @@ public class CreateShopBlockEntity extends BlockEntity {
   /** Consumes tracked inflight quantity for a specific overdue notice tuple. */
   public int consumeInflight(
       ItemStack stackKey, int amount, @Nullable String requesterName, @Nullable String address) {
+    return consumeInflight(stackKey, amount, requesterName, address, -1L);
+  }
+
+  public int consumeInflight(
+      ItemStack stackKey,
+      int amount,
+      @Nullable String requesterName,
+      @Nullable String address,
+      long requestedAt) {
     if (!ensureServerThread("consumeInflight")) {
       return 0;
     }
@@ -333,7 +342,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     int remaining = amount;
     int consumed = 0;
     boolean changed = false;
-    remaining = consumeInflightMatches(stackKey, remaining, requester, destination);
+    remaining = consumeInflightMatches(stackKey, remaining, requester, destination, requestedAt);
     consumed = amount - remaining;
     changed = consumed > 0;
 
@@ -341,7 +350,7 @@ public class CreateShopBlockEntity extends BlockEntity {
     // If strict tuple matching consumed nothing, clear by stack key to avoid stuck overdue loops.
     if (consumed <= 0 && (!requester.isEmpty() || !destination.isEmpty()) && remaining > 0) {
       int before = remaining;
-      remaining = consumeInflightMatches(stackKey, remaining, "", "");
+      remaining = consumeInflightMatches(stackKey, remaining, "", "", requestedAt);
       int fallbackConsumed = before - remaining;
       if (fallbackConsumed > 0) {
         consumed += fallbackConsumed;
@@ -358,6 +367,14 @@ public class CreateShopBlockEntity extends BlockEntity {
   /** Returns currently tracked inflight remainder for a lost-package tuple. */
   public int getInflightRemaining(
       ItemStack stackKey, @Nullable String requesterName, @Nullable String address) {
+    return getInflightRemaining(stackKey, requesterName, address, -1L);
+  }
+
+  public int getInflightRemaining(
+      ItemStack stackKey,
+      @Nullable String requesterName,
+      @Nullable String address,
+      long requestedAt) {
     if (!ensureServerThread("getInflightRemaining")) {
       return 0;
     }
@@ -377,6 +394,9 @@ public class CreateShopBlockEntity extends BlockEntity {
       if (!destination.isEmpty() && !destination.equals(entry.address)) {
         continue;
       }
+      if (requestedAt > 0L && entry.requestedAt != requestedAt) {
+        continue;
+      }
       remaining += Math.max(0, entry.remaining);
     }
     return remaining;
@@ -385,6 +405,14 @@ public class CreateShopBlockEntity extends BlockEntity {
   /** Clears tracked inflight entries for a matching stack/requester/address tuple. */
   public int cancelInflight(
       ItemStack stackKey, @Nullable String requesterName, @Nullable String address) {
+    return cancelInflight(stackKey, requesterName, address, -1L);
+  }
+
+  public int cancelInflight(
+      ItemStack stackKey,
+      @Nullable String requesterName,
+      @Nullable String address,
+      long requestedAt) {
     if (!ensureServerThread("cancelInflight")) {
       return 0;
     }
@@ -393,10 +421,10 @@ public class CreateShopBlockEntity extends BlockEntity {
     }
     String requester = sanitize(requesterName);
     String destination = sanitize(address);
-    int removed = cancelInflightMatches(stackKey, requester, destination);
+    int removed = cancelInflightMatches(stackKey, requester, destination, requestedAt);
     // Fallback: requester labels can drift (hut name vs citizen name); clear by stack+address.
     if (removed <= 0 && !requester.isEmpty()) {
-      removed = cancelInflightMatches(stackKey, "", destination);
+      removed = cancelInflightMatches(stackKey, "", destination, requestedAt);
     }
     if (removed > 0) {
       pruneBaselines();
@@ -405,7 +433,24 @@ public class CreateShopBlockEntity extends BlockEntity {
     return removed;
   }
 
-  private int cancelInflightMatches(ItemStack stackKey, String requester, String destination) {
+  /** Clears reservations and inflight tracking for test/debug clean-state runs. */
+  public int clearRuntimeTrackingForDebug() {
+    if (!ensureServerThread("clearRuntimeTrackingForDebug")) {
+      return 0;
+    }
+    int removed = reservations.size() + inflightEntries.size() + inflightBaselines.size();
+    if (removed <= 0) {
+      return 0;
+    }
+    reservations.clear();
+    inflightEntries.clear();
+    inflightBaselines.clear();
+    setChanged();
+    return removed;
+  }
+
+  private int cancelInflightMatches(
+      ItemStack stackKey, String requester, String destination, long requestedAt) {
     int removed = 0;
     Iterator<InflightEntry> iterator = inflightEntries.iterator();
     while (iterator.hasNext()) {
@@ -419,6 +464,9 @@ public class CreateShopBlockEntity extends BlockEntity {
       if (!destination.isEmpty() && !destination.equals(entry.address)) {
         continue;
       }
+      if (requestedAt > 0L && entry.requestedAt != requestedAt) {
+        continue;
+      }
       removed += Math.max(0, entry.remaining);
       iterator.remove();
     }
@@ -426,7 +474,7 @@ public class CreateShopBlockEntity extends BlockEntity {
   }
 
   private int consumeInflightMatches(
-      ItemStack stackKey, int remaining, String requester, String destination) {
+      ItemStack stackKey, int remaining, String requester, String destination, long requestedAt) {
     Iterator<InflightEntry> iterator = inflightEntries.iterator();
     while (iterator.hasNext() && remaining > 0) {
       InflightEntry entry = iterator.next();
@@ -437,6 +485,9 @@ public class CreateShopBlockEntity extends BlockEntity {
         continue;
       }
       if (!destination.isEmpty() && !destination.equals(entry.address)) {
+        continue;
+      }
+      if (requestedAt > 0L && entry.requestedAt != requestedAt) {
         continue;
       }
       int used = Math.min(remaining, entry.remaining);

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -8,6 +8,7 @@ import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.tileentities.AbstractTileEntityWareHouse;
@@ -851,8 +852,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
             || !isLocalResolver(owner, shopResolver)) {
           continue;
         }
-        if (!(request.getRequest() instanceof IDeliverable deliverable)
-            || !matchesLostPackageDeliverable(deliverable, stackKey)) {
+        if (!matchesLostPackageRequest(standard, request, stackKey)) {
           continue;
         }
         if (!matchesLostPackageRequester(standard, request, requesterName)) {
@@ -903,6 +903,47 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
       return true;
     }
     return ItemStack.isSameItem(result, stackKey);
+  }
+
+  private static boolean matchesLostPackageRequest(
+      IStandardRequestManager manager, IRequest<?> request, ItemStack stackKey) {
+    if (manager == null || request == null || stackKey == null || stackKey.isEmpty()) {
+      return false;
+    }
+    if (matchesLostPackageRequestPayload(request, stackKey)) {
+      return true;
+    }
+    if (!request.hasChildren()) {
+      return false;
+    }
+    for (IToken<?> childToken : request.getChildren()) {
+      if (childToken == null) {
+        continue;
+      }
+      IRequest<?> child = manager.getRequestHandler().getRequest(childToken);
+      if (child != null && matchesLostPackageRequestPayload(child, stackKey)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean matchesLostPackageRequestPayload(IRequest<?> request, ItemStack stackKey) {
+    if (request == null || stackKey == null || stackKey.isEmpty()) {
+      return false;
+    }
+    if (request.getRequest() instanceof IDeliverable deliverable
+        && matchesLostPackageDeliverable(deliverable, stackKey)) {
+      return true;
+    }
+    if (request.getRequest() instanceof Delivery delivery) {
+      ItemStack deliveryStack = delivery.getStack();
+      if (ItemStack.isSameItemSameComponents(deliveryStack, stackKey)
+          || ItemStack.isSameItem(deliveryStack, stackKey)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private boolean matchesLostPackageRequester(

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -92,6 +92,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   private long lastHousekeepingTransferTick = -1L;
   private long lastHousekeepingWorkCheckTick = -1L;
   private long lastHousekeepingDebugTick = -1L;
+  private long lostPackageInteractionEpoch;
   private boolean cachedHasIncomingRackWork;
   private boolean legacyCourierMigrationAttempted;
 
@@ -111,6 +112,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     this.workerStatus = new ShopWorkerStatus(this);
     this.networkNotifier = new ShopNetworkNotifier(this);
     this.resolverFactory = new ShopResolverFactory(this);
+    this.lostPackageInteractionEpoch = 0L;
     this.legacyCourierMigrationAttempted = false;
   }
 
@@ -493,12 +495,13 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   }
 
   public int restartLostPackage(
-      ItemStack stackKey, int remaining, String requesterName, String address) {
-    return restartLostPackageDetailed(stackKey, remaining, requesterName, address).consumed();
+      ItemStack stackKey, int remaining, String requesterName, String address, long requestedAt) {
+    return restartLostPackageDetailed(stackKey, remaining, requesterName, address, requestedAt)
+        .consumed();
   }
 
   LostPackageReorderResult restartLostPackageDetailed(
-      ItemStack stackKey, int remaining, String requesterName, String address) {
+      ItemStack stackKey, int remaining, String requesterName, String address, long requestedAt) {
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package restart requested item={} remaining={} requester='{}' address='{}'",
@@ -526,7 +529,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
       }
       return new LostPackageReorderResult(0, LostPackageReorderStatus.MISSING_CONTEXT);
     }
-    int trackedRemaining = pickup.getInflightRemaining(stackKey, requesterName, address);
+    int trackedRemaining =
+        pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt);
     int reorderTarget = Math.min(Math.max(1, remaining), Math.max(0, trackedRemaining));
     if (reorderTarget <= 0) {
       if (isDebugRequests()) {
@@ -552,7 +556,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         requestedCount += stack.getCount();
       }
     }
-    int consumed = pickup.consumeInflight(stackKey, requestedCount, requesterName, address);
+    int consumed =
+        pickup.consumeInflight(stackKey, requestedCount, requesterName, address, requestedAt);
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package restart requester={} item={} requested={} consumedOld={}",
@@ -565,7 +570,12 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   }
 
   public int acceptLostPackageFromPlayer(
-      Player player, ItemStack stackKey, int remaining, String requesterName, String address) {
+      Player player,
+      ItemStack stackKey,
+      int remaining,
+      String requesterName,
+      String address,
+      long requestedAt) {
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package handover requested player={} item={} remaining={} requester='{}' address='{}'",
@@ -596,7 +606,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     var inventory = player.getInventory();
     rackIndex.ensureRackContainers();
     int targetAmount = Math.max(1, remaining);
-    int inflightBefore = pickup.getInflightRemaining(stackKey, requesterName, address);
+    int inflightBefore = pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt);
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package handover precheck inventorySlots={} target={} inflightBefore={} requester='{}' address='{}'",
@@ -664,7 +674,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         }
         continue;
       }
-      int strictRemaining = pickup.getInflightRemaining(stackKey, requesterName, address);
+      int strictRemaining =
+          pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt);
       int looseRemaining = pickup.getInflightRemaining(stackKey, "", "");
       if (strictRemaining < consumeTarget && looseRemaining < consumeTarget) {
         if (isDebugRequests()) {
@@ -732,7 +743,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
       int insertedMatching = countMatching(unpacked, stackKey) - countMatching(leftovers, stackKey);
       totalInsertedMatching += Math.max(0, insertedMatching);
       consumeTarget = Math.min(targetAmount - totalConsumed, Math.max(0, insertedMatching));
-      int consumed = pickup.consumeInflight(stackKey, consumeTarget, requesterName, address);
+      int consumed =
+          pickup.consumeInflight(stackKey, consumeTarget, requesterName, address, requestedAt);
       totalConsumed += Math.max(0, consumed);
       if (isDebugRequests()) {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
@@ -744,7 +756,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
             totalConsumed,
             targetAmount);
         if (consumed <= 0 && consumeTarget > 0) {
-          strictRemaining = pickup.getInflightRemaining(stackKey, requesterName, address);
+          strictRemaining =
+              pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt);
           looseRemaining = pickup.getInflightRemaining(stackKey, "", "");
           com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
               "[CreateShop] lost-package handover consume-miss slot={} consumeTarget={} strictRemaining={} looseRemaining={}",
@@ -759,7 +772,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         break;
       }
     }
-    int inflightAfter = pickup.getInflightRemaining(stackKey, requesterName, address);
+    int inflightAfter = pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt);
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package handover summary scannedPackages={} matchedPackages={} removedPackages={} insertedMatchingTotal={} consumedTotal={} target={} inflightBefore={} inflightAfter={}",
@@ -783,7 +796,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return 0;
   }
 
-  public int cancelLostPackage(ItemStack stackKey, String requesterName, String address) {
+  public int cancelLostPackage(
+      ItemStack stackKey, String requesterName, String address, long requestedAt) {
     if (stackKey == null || stackKey.isEmpty()) {
       return 0;
     }
@@ -791,7 +805,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     if (pickup == null) {
       return 0;
     }
-    int cleared = pickup.cancelInflight(stackKey, requesterName, address);
+    int cleared = pickup.cancelInflight(stackKey, requesterName, address, requestedAt);
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package cancel item={} requester='{}' address='{}' cleared={}",
@@ -803,9 +817,30 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return cleared;
   }
 
+  /** Clears request runtime tracking caches used by Create Shop for debug/test clean-state runs. */
+  public int clearRuntimeTrackingForDebug() {
+    lostPackageInteractionEpoch++;
+    CreateShopBlockEntity pickup = getPickupBlockEntity();
+    if (pickup == null) {
+      return 0;
+    }
+    int cleared = pickup.clearRuntimeTrackingForDebug();
+    if (isDebugRequests() && cleared > 0) {
+      com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+          "[CreateShop] debug reset runtime tracking shop={} cleared={}",
+          getLocation() == null ? "<unknown>" : getLocation().getInDimensionLocation(),
+          cleared);
+    }
+    return cleared;
+  }
+
+  long getLostPackageInteractionEpoch() {
+    return lostPackageInteractionEpoch;
+  }
+
   public int cancelLostPackageRequestAndInflight(
-      ItemStack stackKey, int remaining, String requesterName, String address) {
-    int clearedInflight = cancelLostPackage(stackKey, requesterName, address);
+      ItemStack stackKey, int remaining, String requesterName, String address, long requestedAt) {
+    int clearedInflight = cancelLostPackage(stackKey, requesterName, address, requestedAt);
     int cancelledRequests = cancelMatchingLostPackageRequests(stackKey, requesterName, address);
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
@@ -847,6 +882,9 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         if (request == null || isTerminalRequestState(request.getState())) {
           continue;
         }
+        if (request.hasParent()) {
+          continue;
+        }
         IRequestResolver<?> owner = standard.getResolverHandler().getResolverForRequest(request);
         if (!(owner instanceof CreateShopRequestResolver shopResolver)
             || !isLocalResolver(owner, shopResolver)) {
@@ -861,6 +899,10 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         standard.updateRequestState(request.getId(), RequestState.CANCELLED);
         cancelled++;
       } catch (Exception ex) {
+        if (tryForceCleanRequest(standard, token, ex)) {
+          cancelled++;
+          continue;
+        }
         if (isDebugRequests()) {
           com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
               "[CreateShop] lost-package cancel request failed token={} error={}",
@@ -870,6 +912,34 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
       }
     }
     return cancelled;
+  }
+
+  private boolean tryForceCleanRequest(
+      IStandardRequestManager standard, IToken<?> token, Exception cause) {
+    if (standard == null || token == null || cause == null) {
+      return false;
+    }
+    String message = cause.getMessage();
+    if (message == null || message.isEmpty()) {
+      return false;
+    }
+    String normalized = message.toLowerCase(java.util.Locale.ROOT);
+    boolean staleGraph =
+        (normalized.contains("haschildren()") && normalized.contains("request"))
+            || normalized.contains("intvalue()");
+    if (!staleGraph) {
+      return false;
+    }
+    try {
+      standard.getRequestHandler().cleanRequestData(token);
+      if (isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] lost-package cancel force-clean token={} reason={}", token, message);
+      }
+      return true;
+    } catch (Exception ignored) {
+      return false;
+    }
   }
 
   private boolean isLocalResolver(IRequestResolver<?> owner, CreateShopRequestResolver resolver) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -5,6 +5,9 @@ import com.minecolonies.api.blocks.AbstractBlockMinecoloniesRack;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.tileentities.AbstractTileEntityWareHouse;
@@ -792,6 +795,161 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
           cleared);
     }
     return cleared;
+  }
+
+  public int cancelLostPackageRequestAndInflight(
+      ItemStack stackKey, int remaining, String requesterName, String address) {
+    int clearedInflight = cancelLostPackage(stackKey, requesterName, address);
+    int cancelledRequests = cancelMatchingLostPackageRequests(stackKey, requesterName, address);
+    if (isDebugRequests()) {
+      com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+          "[CreateShop] lost-package cancel+requests item={} requester='{}' address='{}' clearedInflight={} cancelledRequests={}",
+          stackKey == null || stackKey.isEmpty() ? "<empty>" : stackKey.getHoverName().getString(),
+          requesterName,
+          address,
+          clearedInflight,
+          cancelledRequests);
+    }
+    if (clearedInflight > 0 || cancelledRequests > 0) {
+      return Math.max(Math.max(1, remaining), clearedInflight);
+    }
+    return 0;
+  }
+
+  private int cancelMatchingLostPackageRequests(
+      ItemStack stackKey, String requesterName, String address) {
+    if (stackKey == null || stackKey.isEmpty() || getColony() == null) {
+      return 0;
+    }
+    if (!(getColony().getRequestManager() instanceof IStandardRequestManager standard)) {
+      return 0;
+    }
+    var assignments = standard.getRequestResolverRequestAssignmentDataStore().getAssignments();
+    if (assignments == null || assignments.isEmpty()) {
+      return 0;
+    }
+    java.util.Set<IToken<?>> tokens = new java.util.LinkedHashSet<>();
+    for (var value : assignments.values()) {
+      if (value != null) {
+        tokens.addAll(value);
+      }
+    }
+    int cancelled = 0;
+    for (IToken<?> token : tokens) {
+      try {
+        IRequest<?> request = standard.getRequestHandler().getRequest(token);
+        if (request == null || isTerminalRequestState(request.getState())) {
+          continue;
+        }
+        IRequestResolver<?> owner = standard.getResolverHandler().getResolverForRequest(request);
+        if (!(owner instanceof CreateShopRequestResolver shopResolver)
+            || !isLocalResolver(owner, shopResolver)) {
+          continue;
+        }
+        if (!(request.getRequest() instanceof IDeliverable deliverable)
+            || !matchesLostPackageDeliverable(deliverable, stackKey)) {
+          continue;
+        }
+        if (!matchesLostPackageRequester(standard, request, requesterName)) {
+          continue;
+        }
+        standard.updateRequestState(request.getId(), RequestState.CANCELLED);
+        cancelled++;
+      } catch (Exception ex) {
+        if (isDebugRequests()) {
+          com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+              "[CreateShop] lost-package cancel request failed token={} error={}",
+              token,
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+    }
+    return cancelled;
+  }
+
+  private boolean isLocalResolver(IRequestResolver<?> owner, CreateShopRequestResolver resolver) {
+    if (owner == null
+        || resolver == null
+        || resolver.getLocation() == null
+        || getLocation() == null) {
+      return false;
+    }
+    return resolver.getLocation().equals(getLocation());
+  }
+
+  private static boolean isTerminalRequestState(RequestState state) {
+    return state == RequestState.CANCELLED
+        || state == RequestState.COMPLETED
+        || state == RequestState.FAILED
+        || state == RequestState.RECEIVED
+        || state == RequestState.RESOLVED;
+  }
+
+  private static boolean matchesLostPackageDeliverable(
+      IDeliverable deliverable, ItemStack stackKey) {
+    if (deliverable == null || stackKey == null || stackKey.isEmpty()) {
+      return false;
+    }
+    ItemStack result = deliverable.getResult();
+    if (result == null || result.isEmpty()) {
+      return false;
+    }
+    if (ItemStack.isSameItemSameComponents(result, stackKey)) {
+      return true;
+    }
+    return ItemStack.isSameItem(result, stackKey);
+  }
+
+  private boolean matchesLostPackageRequester(
+      IStandardRequestManager manager, IRequest<?> request, String requesterName) {
+    String expected = normalizeRequesterLabel(requesterName);
+    if (isUnknownRequesterLabel(expected)) {
+      return true;
+    }
+    String actual = resolveRequesterName(manager, request);
+    if (actual.isEmpty()) {
+      return false;
+    }
+    if (actual.equals(expected)) {
+      return true;
+    }
+    return actual.contains(expected) || expected.contains(actual);
+  }
+
+  private String resolveRequesterName(IStandardRequestManager manager, IRequest<?> request) {
+    if (request == null) {
+      return "";
+    }
+    try {
+      var requester = request.getRequester();
+      if (requester == null) {
+        return "";
+      }
+      var display = requester.getRequesterDisplayName(manager, request);
+      if (display == null) {
+        return "";
+      }
+      return normalizeRequesterLabel(display.getString());
+    } catch (Exception ignored) {
+      return "";
+    }
+  }
+
+  private static String normalizeRequesterLabel(String value) {
+    if (value == null) {
+      return "";
+    }
+    String normalized = value.trim().toLowerCase(java.util.Locale.ROOT);
+    return normalized.isEmpty() ? "" : normalized;
+  }
+
+  private static boolean isUnknownRequesterLabel(String requester) {
+    if (requester == null || requester.isEmpty()) {
+      return true;
+    }
+    return requester.equals("unknown")
+        || requester.equals("<unknown>")
+        || requester.equals("unknown requester");
   }
 
   private void ensureWarehouseRegistration() {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -472,6 +472,11 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return cachedHasIncomingRackWork;
   }
 
+  public boolean hasActiveLocalDeliveryChildrenForInflight(IColony colony) {
+    CreateShopBlockEntity pickup = getPickupBlockEntity();
+    return hasActiveLocalDeliveryChildren(colony, pickup);
+  }
+
   public boolean hasUrgentWork() {
     return hasResolverWork();
   }
@@ -819,7 +824,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
 
   /** Clears request runtime tracking caches used by Create Shop for debug/test clean-state runs. */
   public int clearRuntimeTrackingForDebug() {
-    lostPackageInteractionEpoch++;
+    advanceLostPackageInteractionEpoch("debug-reset");
     CreateShopBlockEntity pickup = getPickupBlockEntity();
     if (pickup == null) {
       return 0;
@@ -836,6 +841,16 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
 
   long getLostPackageInteractionEpoch() {
     return lostPackageInteractionEpoch;
+  }
+
+  void advanceLostPackageInteractionEpoch(String reason) {
+    lostPackageInteractionEpoch++;
+    if (isDebugRequests()) {
+      com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+          "[CreateShop] lost-package interaction epoch advanced to {} reason={}",
+          lostPackageInteractionEpoch,
+          reason == null ? "<none>" : reason);
+    }
   }
 
   public int cancelLostPackageRequestAndInflight(
@@ -1112,6 +1127,15 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
       }
       return;
     }
+    if (hasActiveLocalDeliveryChildren(colony, pickup)) {
+      cachedHasIncomingRackWork = tile.hasUnreservedRackItems(pickup);
+      if (isDebugRequests() && shouldLogHousekeepingDebug(now)) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] housekeeping blocked reason=active-delivery-child pendingUnreserved={}",
+            cachedHasIncomingRackWork);
+      }
+      return;
+    }
     CreateShopRequestResolver resolver = getOrCreateShopResolver();
     if (resolver != null && resolver.hasActiveWork()) {
       cachedHasIncomingRackWork = tile.hasUnreservedRackItems(pickup);
@@ -1155,6 +1179,109 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
           transferBudget,
           elapsed);
     }
+  }
+
+  private boolean hasActiveLocalDeliveryChildren(IColony colony, CreateShopBlockEntity pickup) {
+    if (colony == null || pickup == null || pickup.getLevel() == null) {
+      return false;
+    }
+    if (!(colony.getRequestManager() instanceof IStandardRequestManager standard)) {
+      return false;
+    }
+    var assignmentStore = standard.getRequestResolverRequestAssignmentDataStore();
+    if (assignmentStore == null) {
+      return false;
+    }
+    Map<IToken<?>, java.util.Collection<IToken<?>>> assignments = assignmentStore.getAssignments();
+    if (assignments == null || assignments.isEmpty()) {
+      return false;
+    }
+    var requestHandler = standard.getRequestHandler();
+    if (requestHandler == null) {
+      return false;
+    }
+    for (var assignmentEntry : assignments.entrySet()) {
+      java.util.Collection<IToken<?>> assigned = assignmentEntry.getValue();
+      if (assigned == null || assigned.isEmpty()) {
+        continue;
+      }
+      for (IToken<?> token : java.util.List.copyOf(assigned)) {
+        if (token == null) {
+          continue;
+        }
+        try {
+          IRequest<?> request = requestHandler.getRequest(token);
+          if (request == null || !(request.getRequest() instanceof Delivery delivery)) {
+            continue;
+          }
+          RequestState state = request.getState();
+          boolean activeState =
+              state == RequestState.CREATED
+                  || state == RequestState.ASSIGNED
+                  || state == RequestState.IN_PROGRESS;
+          if (!activeState) {
+            continue;
+          }
+          if (!isLocalDeliveryStart(delivery, pickup)) {
+            continue;
+          }
+          if (!isLocalCreateShopDeliveryParent(standard, request)) {
+            continue;
+          }
+          return true;
+        } catch (Exception ex) {
+          if (isDebugRequests()) {
+            com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] housekeeping delivery-child check failed token={} error={}",
+                token,
+                ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+          }
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private boolean isLocalCreateShopDeliveryParent(
+      IStandardRequestManager standard, IRequest<?> child) {
+    if (standard == null || child == null || !child.hasParent()) {
+      return false;
+    }
+    try {
+      IRequest<?> parent = standard.getRequestHandler().getRequest(child.getParent());
+      if (parent == null) {
+        return false;
+      }
+      IRequestResolver<?> owner = standard.getResolverHandler().getResolverForRequest(parent);
+      if (!(owner instanceof CreateShopRequestResolver resolver)) {
+        return false;
+      }
+      return resolver.getLocation() != null && resolver.getLocation().equals(getLocation());
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  private boolean isLocalDeliveryStart(Delivery delivery, CreateShopBlockEntity pickup) {
+    if (delivery == null || pickup == null || pickup.getLevel() == null) {
+      return false;
+    }
+    var start = delivery.getStart();
+    if (start == null || start.getDimension() == null) {
+      return false;
+    }
+    if (!pickup.getLevel().dimension().equals(start.getDimension())) {
+      return false;
+    }
+    BlockPos startPos = start.getInDimensionLocation();
+    if (startPos == null) {
+      return false;
+    }
+    if (pickup.getBlockPos().equals(startPos)) {
+      return true;
+    }
+    return hasContainerPosition(startPos);
   }
 
   private boolean shouldLogHousekeepingDebug(long now) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -493,6 +493,11 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
 
   public int restartLostPackage(
       ItemStack stackKey, int remaining, String requesterName, String address) {
+    return restartLostPackageDetailed(stackKey, remaining, requesterName, address).consumed();
+  }
+
+  LostPackageReorderResult restartLostPackageDetailed(
+      ItemStack stackKey, int remaining, String requesterName, String address) {
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package restart requested item={} remaining={} requester='{}' address='{}'",
@@ -506,7 +511,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
             "[CreateShop] lost-package restart rejected: invalid input");
       }
-      return 0;
+      return new LostPackageReorderResult(0, LostPackageReorderStatus.INVALID_INPUT);
     }
     TileEntityCreateShop tile = getCreateShopTileEntity();
     CreateShopBlockEntity pickup = getPickupBlockEntity();
@@ -518,7 +523,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
             pickup != null,
             tile != null && tile.getStockNetworkId() != null);
       }
-      return 0;
+      return new LostPackageReorderResult(0, LostPackageReorderStatus.MISSING_CONTEXT);
     }
     int trackedRemaining = pickup.getInflightRemaining(stackKey, requesterName, address);
     int reorderTarget = Math.min(Math.max(1, remaining), Math.max(0, trackedRemaining));
@@ -527,7 +532,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
             "[CreateShop] lost-package restart skipped: no tracked inflight remaining for tuple");
       }
-      return 0;
+      return new LostPackageReorderResult(0, LostPackageReorderStatus.NO_TRACKED_INFLIGHT);
     }
     ItemStack requested = stackKey.copy();
     requested.setCount(reorderTarget);
@@ -538,7 +543,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
             "[CreateShop] lost-package restart failed: network returned empty reorder list");
       }
-      return 0;
+      return new LostPackageReorderResult(0, LostPackageReorderStatus.NO_NETWORK_STOCK);
     }
     int requestedCount = 0;
     for (ItemStack stack : reordered) {
@@ -555,7 +560,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
           requestedCount,
           consumed);
     }
-    return consumed;
+    return new LostPackageReorderResult(consumed, LostPackageReorderStatus.SUCCESS);
   }
 
   public int acceptLostPackageFromPlayer(
@@ -950,6 +955,16 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return requester.equals("unknown")
         || requester.equals("<unknown>")
         || requester.equals("unknown requester");
+  }
+
+  record LostPackageReorderResult(int consumed, LostPackageReorderStatus status) {}
+
+  enum LostPackageReorderStatus {
+    SUCCESS,
+    INVALID_INPUT,
+    MISSING_CONTEXT,
+    NO_TRACKED_INFLIGHT,
+    NO_NETWORK_STOCK
   }
 
   private void ensureWarehouseRegistration() {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -856,7 +856,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   public int cancelLostPackageRequestAndInflight(
       ItemStack stackKey, int remaining, String requesterName, String address, long requestedAt) {
     int clearedInflight = cancelLostPackage(stackKey, requesterName, address, requestedAt);
-    int cancelledRequests = cancelMatchingLostPackageRequests(stackKey, requesterName, address);
+    int cancelledRequests =
+        cancelMatchingLostPackageRequests(stackKey, requesterName, address, requestedAt);
     if (isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package cancel+requests item={} requester='{}' address='{}' clearedInflight={} cancelledRequests={}",
@@ -873,7 +874,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   }
 
   private int cancelMatchingLostPackageRequests(
-      ItemStack stackKey, String requesterName, String address) {
+      ItemStack stackKey, String requesterName, String address, long requestedAt) {
     if (stackKey == null || stackKey.isEmpty() || getColony() == null) {
       return 0;
     }
@@ -890,6 +891,7 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         tokens.addAll(value);
       }
     }
+    boolean tupleScoped = requestedAt > 0L;
     int cancelled = 0;
     for (IToken<?> token : tokens) {
       try {
@@ -911,8 +913,16 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
         if (!matchesLostPackageRequester(standard, request, requesterName)) {
           continue;
         }
+        if (!matchesLostPackageAddress(standard, request, address)) {
+          continue;
+        }
         standard.updateRequestState(request.getId(), RequestState.CANCELLED);
         cancelled++;
+        if (tupleScoped) {
+          // requestedAt is tuple-scoped; without a stable request timestamp in MineColonies
+          // requests, cancel only a single matched root request to avoid collateral cancels.
+          break;
+        }
       } catch (Exception ex) {
         if (tryForceCleanRequest(standard, token, ex)) {
           cancelled++;
@@ -1047,7 +1057,39 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return actual.contains(expected) || expected.contains(actual);
   }
 
+  private boolean matchesLostPackageAddress(
+      IStandardRequestManager manager, IRequest<?> request, String address) {
+    String expected = normalizeRequesterLabel(address);
+    if (expected.isEmpty() || expected.equals("unknown address") || expected.equals("<unknown>")) {
+      return true;
+    }
+    String requesterDisplay = resolveRequesterDisplay(manager, request);
+    if (!requesterDisplay.isEmpty()
+        && (requesterDisplay.contains(expected) || expected.contains(requesterDisplay))) {
+      return true;
+    }
+    String shortDisplay = normalizeRequesterLabel(request == null ? "" : request.getShortDisplayString().getString());
+    if (!shortDisplay.isEmpty()
+        && (shortDisplay.contains(expected) || expected.contains(shortDisplay))) {
+      return true;
+    }
+    String longDisplay = normalizeRequesterLabel(request == null ? "" : request.getLongDisplayString().getString());
+    if (!longDisplay.isEmpty()
+        && (longDisplay.contains(expected) || expected.contains(longDisplay))) {
+      return true;
+    }
+    return false;
+  }
+
   private String resolveRequesterName(IStandardRequestManager manager, IRequest<?> request) {
+    String display = resolveRequesterDisplay(manager, request);
+    if (display.isEmpty()) {
+      return "";
+    }
+    return display;
+  }
+
+  private String resolveRequesterDisplay(IStandardRequestManager manager, IRequest<?> request) {
     if (request == null) {
       return "";
     }

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -1044,7 +1044,8 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     }
     // Ownership is authoritative for pending processing; prefer it when drift is detected.
     CreateShopRequestResolver ownershipSelected = findResolverFromRequestOwnership(manager);
-    if (ownershipSelected != null && (selected == null || !selected.getId().equals(ownershipSelected.getId()))) {
+    if (ownershipSelected != null
+        && (selected == null || !selected.getId().equals(ownershipSelected.getId()))) {
       if (isDebugRequests()) {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
             "[CreateShop] resolver ownership priority switch {} -> {}",

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopInflightTracker.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopInflightTracker.java
@@ -79,7 +79,12 @@ final class ShopInflightTracker {
       }
       ShopLostPackageInteraction interaction =
           new ShopLostPackageInteraction(
-              notice.stackKey.copy(), notice.remaining, notice.requesterName, notice.address);
+              notice.stackKey.copy(),
+              notice.remaining,
+              notice.requesterName,
+              notice.address,
+              notice.requestedAt,
+              shop.getLostPackageInteractionEpoch());
       if (BuildingCreateShop.isDebugRequests()) {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
             "[CreateShop] lost-package interaction trigger dispatch citizen={} interactionId={}",

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopInflightTracker.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopInflightTracker.java
@@ -44,6 +44,14 @@ final class ShopInflightTracker {
     }
     var currentCounts = shop.getStockCountsForKeys(inflightKeys);
     pickup.reconcileInflight(currentCounts);
+    if (shop.hasActiveLocalDeliveryChildrenForInflight(colony)) {
+      if (BuildingCreateShop.isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] lost-package interaction skipped: local delivery still active");
+      }
+      notifyShopkeeperCapacityStall();
+      return;
+    }
     List<CreateShopBlockEntity.InflightNotice> notices =
         pickup.consumeOverdueNotices(now, Config.INFLIGHT_TIMEOUT_TICKS.getAsLong());
     if (!notices.isEmpty()) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
@@ -109,10 +109,30 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
       }
       return;
     }
+    // Lock interaction immediately to avoid duplicate reopen windows while handling a response.
+    active = false;
     boolean handled = false;
     int consumed = 0;
     if (response == 0) {
-      consumed = shop.restartLostPackage(stackKey, remaining, requesterName, address);
+      BuildingCreateShop.LostPackageReorderResult reorder =
+          shop.restartLostPackageDetailed(stackKey, remaining, requesterName, address);
+      consumed = reorder.consumed();
+      if (reorder.status() == BuildingCreateShop.LostPackageReorderStatus.NO_NETWORK_STOCK) {
+        active = false;
+        if (remaining > 0) {
+          citizen.triggerInteraction(
+              new ShopLostPackageReorderUnavailableInteraction(
+                  stackKey.copy(), remaining, requesterName, address));
+        }
+        if (BuildingCreateShop.isDebugRequests()) {
+          com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+              "[CreateShop] lost-package interaction reorder unavailable debugId={} item={} remaining={}",
+              debugInstanceId,
+              stackKey.isEmpty() ? "<empty>" : stackKey.getHoverName().getString(),
+              remaining);
+        }
+        return;
+      }
     } else if (response == 1) {
       consumed =
           shop.acceptLostPackageFromPlayer(player, stackKey, remaining, requesterName, address);
@@ -135,6 +155,10 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     if (handled) {
       active = false;
       remaining = 0;
+    } else if (consumed <= 0) {
+      // Re-arm the dialog when nothing was consumed and no dedicated fallback interaction took
+      // over.
+      active = true;
     }
   }
 

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
@@ -6,9 +6,11 @@ import com.minecolonies.api.colony.interactionhandling.ChatPriority;
 import com.minecolonies.api.util.Tuple;
 import com.minecolonies.core.colony.interactionhandling.ServerCitizenInteraction;
 import com.simibubi.create.content.logistics.box.PackageItem;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -143,6 +145,7 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     }
     // Lock interaction immediately to avoid duplicate reopen windows while handling a response.
     active = false;
+    removeQueuedLostPackageInteractions(citizen);
     boolean handled = false;
     int consumed = 0;
     if (response == 0) {
@@ -416,5 +419,88 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
       return true;
     }
     return ItemStack.isSameItem(candidate, key);
+  }
+
+  private void removeQueuedLostPackageInteractions(ICitizenData citizen) {
+    if (citizen == null) {
+      return;
+    }
+    Field field = findField(citizen.getClass(), "citizenChatOptions");
+    if (field == null) {
+      return;
+    }
+    try {
+      field.setAccessible(true);
+      Object raw = field.get(citizen);
+      if (!(raw instanceof Map<?, ?> rawMap)) {
+        return;
+      }
+      @SuppressWarnings("unchecked")
+      Map<Object, Object> interactions = (Map<Object, Object>) rawMap;
+      int before = interactions.size();
+      interactions.entrySet().removeIf(this::isSameLostPackageInteraction);
+      int removed = Math.max(0, before - interactions.size());
+      if (removed > 0) {
+        citizen.markDirty(0);
+      }
+      if (removed > 0 && BuildingCreateShop.isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] lost-package interaction immediate-remove debugId={} removed={}",
+            debugInstanceId,
+            removed);
+      }
+    } catch (Exception ex) {
+      if (BuildingCreateShop.isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] lost-package interaction immediate-remove failed debugId={} err={}",
+            debugInstanceId,
+            ex.getClass().getSimpleName());
+      }
+    }
+  }
+
+  private static Field findField(Class<?> type, String name) {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(name);
+      } catch (NoSuchFieldException ignored) {
+        current = current.getSuperclass();
+      }
+    }
+    return null;
+  }
+
+  private boolean isSameLostPackageInteraction(Map.Entry<Object, Object> entry) {
+    Object value = entry == null ? null : entry.getValue();
+    if (!(value instanceof ShopLostPackageInteraction other)) {
+      return false;
+    }
+    if (other == this) {
+      return true;
+    }
+    if (!sameStackKey(other.stackKey)) {
+      return false;
+    }
+    if (other.requestedAt != requestedAt) {
+      return false;
+    }
+    if (!sanitize(other.requesterName).equals(sanitize(requesterName))) {
+      return false;
+    }
+    if (!sanitize(other.address).equals(sanitize(address))) {
+      return false;
+    }
+    return true;
+  }
+
+  private boolean sameStackKey(ItemStack otherKey) {
+    if (stackKey == null || stackKey.isEmpty() || otherKey == null || otherKey.isEmpty()) {
+      return false;
+    }
+    if (ItemStack.isSameItemSameComponents(stackKey, otherKey)) {
+      return true;
+    }
+    return ItemStack.isSameItem(stackKey, otherKey);
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
@@ -25,12 +25,16 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
   private static final String TAG_REMAINING = "Remaining";
   private static final String TAG_REQUESTER = "Requester";
   private static final String TAG_ADDRESS = "Address";
+  private static final String TAG_REQUESTED_AT = "RequestedAt";
+  private static final String TAG_EPOCH = "Epoch";
   private static final String TAG_ACTIVE = "Active";
 
   private ItemStack stackKey = ItemStack.EMPTY;
   private int remaining;
   private String requesterName = "";
   private String address = "";
+  private long requestedAt = -1L;
+  private long interactionEpoch;
   private boolean active = true;
   private final long debugInstanceId = DEBUG_INSTANCE_SEQ.getAndIncrement();
 
@@ -39,7 +43,17 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
   }
 
   public ShopLostPackageInteraction(
-      ItemStack stackKey, int remaining, String requesterName, String address) {
+      ItemStack stackKey, int remaining, String requesterName, String address, long requestedAt) {
+    this(stackKey, remaining, requesterName, address, requestedAt, 0L);
+  }
+
+  public ShopLostPackageInteraction(
+      ItemStack stackKey,
+      int remaining,
+      String requesterName,
+      String address,
+      long requestedAt,
+      long interactionEpoch) {
     super(
         buildInquiry(stackKey, remaining, requesterName, address),
         true,
@@ -66,6 +80,8 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     this.remaining = Math.max(0, remaining);
     this.requesterName = sanitize(requesterName);
     this.address = sanitize(address);
+    this.requestedAt = requestedAt;
+    this.interactionEpoch = interactionEpoch;
     if (BuildingCreateShop.isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package interaction created debugId={} item={} remaining={} requester='{}' address='{}'",
@@ -109,20 +125,34 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
       }
       return;
     }
+    if (!isStillTracked(shop)) {
+      active = false;
+      if (BuildingCreateShop.isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] lost-package interaction stale debugId={} item={} remaining={} requester='{}' address='{}' requestedAt={} epoch={} shopEpoch={}",
+            debugInstanceId,
+            stackKey.isEmpty() ? "<empty>" : stackKey.getHoverName().getString(),
+            remaining,
+            requesterName,
+            address,
+            requestedAt,
+            interactionEpoch,
+            shop.getLostPackageInteractionEpoch());
+      }
+      return;
+    }
     // Lock interaction immediately to avoid duplicate reopen windows while handling a response.
     active = false;
     boolean handled = false;
     int consumed = 0;
     if (response == 0) {
       BuildingCreateShop.LostPackageReorderResult reorder =
-          shop.restartLostPackageDetailed(stackKey, remaining, requesterName, address);
+          shop.restartLostPackageDetailed(stackKey, remaining, requesterName, address, requestedAt);
       consumed = reorder.consumed();
       if (reorder.status() == BuildingCreateShop.LostPackageReorderStatus.NO_NETWORK_STOCK) {
         active = false;
         if (remaining > 0) {
-          citizen.triggerInteraction(
-              new ShopLostPackageReorderUnavailableInteraction(
-                  stackKey.copy(), remaining, requesterName, address));
+          deferReorderUnavailableInteraction(citizen);
         }
         if (BuildingCreateShop.isDebugRequests()) {
           com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
@@ -135,10 +165,12 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
       }
     } else if (response == 1) {
       consumed =
-          shop.acceptLostPackageFromPlayer(player, stackKey, remaining, requesterName, address);
+          shop.acceptLostPackageFromPlayer(
+              player, stackKey, remaining, requesterName, address, requestedAt);
     } else if (response == 2) {
       consumed =
-          shop.cancelLostPackageRequestAndInflight(stackKey, remaining, requesterName, address);
+          shop.cancelLostPackageRequestAndInflight(
+              stackKey, remaining, requesterName, address, requestedAt);
     }
     if (consumed > 0) {
       remaining = Math.max(0, remaining - consumed);
@@ -164,6 +196,11 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
 
   @Override
   public boolean isValid(ICitizenData citizen) {
+    if (active && citizen != null && citizen.getWorkBuilding() instanceof BuildingCreateShop shop) {
+      if (!isStillTracked(shop)) {
+        active = false;
+      }
+    }
     if (BuildingCreateShop.isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] lost-package interaction isValid debugId={} active={} citizen={}",
@@ -187,6 +224,29 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     return Collections.emptyList();
   }
 
+  private void deferReorderUnavailableInteraction(ICitizenData citizen) {
+    if (citizen == null || remaining <= 0 || stackKey.isEmpty()) {
+      return;
+    }
+    Runnable trigger =
+        () ->
+            citizen.triggerInteraction(
+                new ShopLostPackageReorderUnavailableInteraction(
+                    stackKey.copy(),
+                    remaining,
+                    requesterName,
+                    address,
+                    requestedAt,
+                    interactionEpoch));
+    net.minecraft.world.level.Level level =
+        citizen.getColony() == null ? null : citizen.getColony().getWorld();
+    if (level != null && level.getServer() != null) {
+      level.getServer().execute(trigger);
+      return;
+    }
+    trigger.run();
+  }
+
   @Override
   public CompoundTag serializeNBT(HolderLookup.Provider provider) {
     CompoundTag tag = super.serializeNBT(provider);
@@ -201,6 +261,12 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     }
     if (!address.isEmpty()) {
       tag.putString(TAG_ADDRESS, address);
+    }
+    if (requestedAt > 0L) {
+      tag.putLong(TAG_REQUESTED_AT, requestedAt);
+    }
+    if (interactionEpoch > 0L) {
+      tag.putLong(TAG_EPOCH, interactionEpoch);
     }
     if (!active) {
       tag.putBoolean(TAG_ACTIVE, false);
@@ -218,6 +284,8 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     remaining = Math.max(0, tag.getInt(TAG_REMAINING));
     requesterName = sanitize(tag.getString(TAG_REQUESTER));
     address = sanitize(tag.getString(TAG_ADDRESS));
+    requestedAt = tag.contains(TAG_REQUESTED_AT) ? tag.getLong(TAG_REQUESTED_AT) : -1L;
+    interactionEpoch = tag.contains(TAG_EPOCH) ? tag.getLong(TAG_EPOCH) : 0L;
     active = !tag.contains(TAG_ACTIVE) || tag.getBoolean(TAG_ACTIVE);
     if (BuildingCreateShop.isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
@@ -316,6 +384,28 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     }
     String trimmed = value.trim();
     return trimmed.isEmpty() ? "" : trimmed;
+  }
+
+  private boolean isStillTracked(BuildingCreateShop shop) {
+    if (shop == null || stackKey == null || stackKey.isEmpty() || remaining <= 0) {
+      return false;
+    }
+    if (interactionEpoch > 0L && interactionEpoch != shop.getLostPackageInteractionEpoch()) {
+      return false;
+    }
+    var pickup = shop.getPickupBlockEntity();
+    if (pickup == null) {
+      return false;
+    }
+    int strictRemaining =
+        pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt);
+    if (strictRemaining > 0) {
+      return true;
+    }
+    if (requestedAt > 0L) {
+      return false;
+    }
+    return pickup.getInflightRemaining(stackKey, requesterName, address) > 0;
   }
 
   private static boolean matchesForRecovery(ItemStack candidate, ItemStack key) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
@@ -55,7 +55,12 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
             Component.translatable(
                 "com.thesettler_x_create.interaction.createshop.lost_package.response_handover"),
             Component.translatable(
-                "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover")));
+                "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover")),
+        new Tuple<>(
+            Component.translatable(
+                "com.thesettler_x_create.interaction.createshop.lost_package.response_cancel"),
+            Component.translatable(
+                "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel")));
     this.stackKey = stackKey == null ? ItemStack.EMPTY : stackKey.copy();
     this.stackKey.setCount(1);
     this.remaining = Math.max(0, remaining);
@@ -111,6 +116,9 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
     } else if (response == 1) {
       consumed =
           shop.acceptLostPackageFromPlayer(player, stackKey, remaining, requesterName, address);
+    } else if (response == 2) {
+      consumed =
+          shop.cancelLostPackageRequestAndInflight(stackKey, remaining, requesterName, address);
     }
     if (consumed > 0) {
       remaining = Math.max(0, remaining - consumed);

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java
@@ -477,7 +477,8 @@ public class ShopLostPackageInteraction extends ServerCitizenInteraction {
       return false;
     }
     if (other == this) {
-      return true;
+      // Keep the currently handled interaction queued so a no-op response can re-arm it.
+      return false;
     }
     if (!sameStackKey(other.stackKey)) {
       return false;

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteraction.java
@@ -19,12 +19,16 @@ public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenI
   private static final String TAG_REMAINING = "Remaining";
   private static final String TAG_REQUESTER = "Requester";
   private static final String TAG_ADDRESS = "Address";
+  private static final String TAG_REQUESTED_AT = "RequestedAt";
+  private static final String TAG_EPOCH = "Epoch";
   private static final String TAG_ACTIVE = "Active";
 
   private ItemStack stackKey = ItemStack.EMPTY;
   private int remaining;
   private String requesterName = "";
   private String address = "";
+  private long requestedAt = -1L;
+  private long interactionEpoch;
   private boolean active = true;
 
   public ShopLostPackageReorderUnavailableInteraction(ICitizen citizen) {
@@ -32,7 +36,17 @@ public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenI
   }
 
   public ShopLostPackageReorderUnavailableInteraction(
-      ItemStack stackKey, int remaining, String requesterName, String address) {
+      ItemStack stackKey, int remaining, String requesterName, String address, long requestedAt) {
+    this(stackKey, remaining, requesterName, address, requestedAt, 0L);
+  }
+
+  public ShopLostPackageReorderUnavailableInteraction(
+      ItemStack stackKey,
+      int remaining,
+      String requesterName,
+      String address,
+      long requestedAt,
+      long interactionEpoch) {
     super(
         buildInquiry(stackKey, remaining, requesterName, address),
         true,
@@ -50,6 +64,8 @@ public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenI
     this.remaining = Math.max(1, remaining);
     this.requesterName = sanitize(requesterName);
     this.address = sanitize(address);
+    this.requestedAt = requestedAt;
+    this.interactionEpoch = interactionEpoch;
   }
 
   @Override
@@ -58,8 +74,20 @@ public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenI
     if (citizen == null || remaining <= 0 || stackKey.isEmpty()) {
       return;
     }
+    if (!(citizen.getWorkBuilding() instanceof BuildingCreateShop shop)) {
+      return;
+    }
+    if (interactionEpoch > 0L && interactionEpoch != shop.getLostPackageInteractionEpoch()) {
+      return;
+    }
+    var pickup = shop.getPickupBlockEntity();
+    if (pickup == null
+        || pickup.getInflightRemaining(stackKey, requesterName, address, requestedAt) <= 0) {
+      return;
+    }
     citizen.triggerInteraction(
-        new ShopLostPackageInteraction(stackKey.copy(), remaining, requesterName, address));
+        new ShopLostPackageInteraction(
+            stackKey.copy(), remaining, requesterName, address, requestedAt, interactionEpoch));
   }
 
   @Override
@@ -94,6 +122,12 @@ public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenI
     if (!address.isEmpty()) {
       tag.putString(TAG_ADDRESS, address);
     }
+    if (requestedAt > 0L) {
+      tag.putLong(TAG_REQUESTED_AT, requestedAt);
+    }
+    if (interactionEpoch > 0L) {
+      tag.putLong(TAG_EPOCH, interactionEpoch);
+    }
     if (!active) {
       tag.putBoolean(TAG_ACTIVE, false);
     }
@@ -110,6 +144,8 @@ public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenI
     remaining = Math.max(0, tag.getInt(TAG_REMAINING));
     requesterName = sanitize(tag.getString(TAG_REQUESTER));
     address = sanitize(tag.getString(TAG_ADDRESS));
+    requestedAt = tag.contains(TAG_REQUESTED_AT) ? tag.getLong(TAG_REQUESTED_AT) : -1L;
+    interactionEpoch = tag.contains(TAG_EPOCH) ? tag.getLong(TAG_EPOCH) : 0L;
     active = !tag.contains(TAG_ACTIVE) || tag.getBoolean(TAG_ACTIVE);
   }
 

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteraction.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteraction.java
@@ -1,0 +1,145 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import com.minecolonies.api.colony.ICitizen;
+import com.minecolonies.api.colony.ICitizenData;
+import com.minecolonies.api.colony.interactionhandling.ChatPriority;
+import com.minecolonies.api.util.Tuple;
+import com.minecolonies.core.colony.interactionhandling.ServerCitizenInteraction;
+import java.util.Collections;
+import java.util.List;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+/** One-shot info interaction for reorder failures due to unavailable stock network items. */
+public class ShopLostPackageReorderUnavailableInteraction extends ServerCitizenInteraction {
+  private static final String TAG_STACK = "Stack";
+  private static final String TAG_REMAINING = "Remaining";
+  private static final String TAG_REQUESTER = "Requester";
+  private static final String TAG_ADDRESS = "Address";
+  private static final String TAG_ACTIVE = "Active";
+
+  private ItemStack stackKey = ItemStack.EMPTY;
+  private int remaining;
+  private String requesterName = "";
+  private String address = "";
+  private boolean active = true;
+
+  public ShopLostPackageReorderUnavailableInteraction(ICitizen citizen) {
+    super(citizen);
+  }
+
+  public ShopLostPackageReorderUnavailableInteraction(
+      ItemStack stackKey, int remaining, String requesterName, String address) {
+    super(
+        buildInquiry(stackKey, remaining, requesterName, address),
+        true,
+        ChatPriority.IMPORTANT,
+        data -> true,
+        Component.translatable(
+            "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.id"),
+        new Tuple<>(
+            Component.translatable(
+                "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.response_back"),
+            Component.translatable(
+                "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.answer_back")));
+    this.stackKey = stackKey == null ? ItemStack.EMPTY : stackKey.copy();
+    this.stackKey.setCount(1);
+    this.remaining = Math.max(1, remaining);
+    this.requesterName = sanitize(requesterName);
+    this.address = sanitize(address);
+  }
+
+  @Override
+  public void onServerResponseTriggered(int response, Player player, ICitizenData citizen) {
+    active = false;
+    if (citizen == null || remaining <= 0 || stackKey.isEmpty()) {
+      return;
+    }
+    citizen.triggerInteraction(
+        new ShopLostPackageInteraction(stackKey.copy(), remaining, requesterName, address));
+  }
+
+  @Override
+  public boolean isValid(ICitizenData citizen) {
+    return active;
+  }
+
+  @Override
+  public String getType() {
+    return com.minecolonies.api.colony.interactionhandling.ModInteractionResponseHandlers.STANDARD
+        .getPath();
+  }
+
+  @Override
+  public List<com.minecolonies.api.colony.interactionhandling.IInteractionResponseHandler>
+      genChildInteractions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public CompoundTag serializeNBT(HolderLookup.Provider provider) {
+    CompoundTag tag = super.serializeNBT(provider);
+    if (!stackKey.isEmpty()) {
+      tag.put(TAG_STACK, stackKey.save(provider));
+    }
+    if (remaining > 0) {
+      tag.putInt(TAG_REMAINING, remaining);
+    }
+    if (!requesterName.isEmpty()) {
+      tag.putString(TAG_REQUESTER, requesterName);
+    }
+    if (!address.isEmpty()) {
+      tag.putString(TAG_ADDRESS, address);
+    }
+    if (!active) {
+      tag.putBoolean(TAG_ACTIVE, false);
+    }
+    return tag;
+  }
+
+  @Override
+  public void deserializeNBT(HolderLookup.Provider provider, CompoundTag tag) {
+    super.deserializeNBT(provider, tag);
+    stackKey =
+        tag.contains(TAG_STACK)
+            ? ItemStack.parse(provider, tag.getCompound(TAG_STACK)).orElse(ItemStack.EMPTY)
+            : ItemStack.EMPTY;
+    remaining = Math.max(0, tag.getInt(TAG_REMAINING));
+    requesterName = sanitize(tag.getString(TAG_REQUESTER));
+    address = sanitize(tag.getString(TAG_ADDRESS));
+    active = !tag.contains(TAG_ACTIVE) || tag.getBoolean(TAG_ACTIVE);
+  }
+
+  private static Component buildInquiry(
+      ItemStack stackKey, int remaining, String requesterName, String address) {
+    String requester = sanitize(requesterName);
+    if (requester.isEmpty()) {
+      requester = "unknown requester";
+    }
+    String destination = sanitize(address);
+    if (destination.isEmpty()) {
+      destination = "unknown address";
+    }
+    String itemLabel =
+        stackKey == null || stackKey.isEmpty()
+            ? "unknown item"
+            : stackKey.getHoverName().getString();
+    return Component.translatable(
+        "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.inquiry",
+        requester,
+        itemLabel,
+        Math.max(1, remaining),
+        destination);
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? "" : trimmed;
+  }
+}

--- a/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
@@ -84,7 +84,7 @@ public final class CreateShopMaintenanceCommands {
         Commands.literal("reset_live_state")
             .executes(
                 context -> {
-                  ResetLiveStateResult result = resetLiveState();
+                  ResetLiveStateResult result = resetLiveState(false);
                   context
                       .getSource()
                       .sendSuccess(
@@ -100,11 +100,72 @@ public final class CreateShopMaintenanceCommands {
                                       + result.staleCleaned
                                       + ", runtimeTrackingCleared="
                                       + result.runtimeTrackingCleared
+                                      + ", runtimeTrackingSkipped="
+                                      + result.runtimeTrackingSkipped
+                                      + ", queueEntriesCleared="
+                                      + result.queueEntriesCleared
+                                      + ", queueRequestsCancelled="
+                                      + result.queueRequestsCancelled
+                                      + ", blockedActiveDeliveries="
+                                      + result.blockedActiveDeliveries
+                                      + ", assignmentPruned="
+                                      + result.assignmentPruned
+                                      + ", deliveryAssignKicks="
+                                      + result.deliveryAssignKicks
+                                      + ", deliveryRequestsCancelled="
+                                      + result.deliveryRequestsCancelled
+                                      + ", drainRounds="
+                                      + result.drainRounds
+                                      + ", drainResiduals="
+                                      + result.drainResiduals
                                       + ", errors="
                                       + result.errors),
                           true);
                   return result.errors == 0 ? 1 : 0;
-                }));
+                })
+            .then(
+                Commands.literal("force_warehouse_queue")
+                    .executes(
+                        context -> {
+                          ResetLiveStateResult result = resetLiveState(true);
+                          context
+                              .getSource()
+                              .sendSuccess(
+                                  () ->
+                                      Component.literal(
+                                          "[CreateShop] Live state reset (force queue): colonies="
+                                              + result.colonies
+                                              + ", shops="
+                                              + result.shops
+                                              + ", requestsCancelled="
+                                              + result.requestsCancelled
+                                              + ", staleCleaned="
+                                              + result.staleCleaned
+                                              + ", runtimeTrackingCleared="
+                                              + result.runtimeTrackingCleared
+                                              + ", runtimeTrackingSkipped="
+                                              + result.runtimeTrackingSkipped
+                                              + ", queueEntriesCleared="
+                                              + result.queueEntriesCleared
+                                              + ", queueRequestsCancelled="
+                                              + result.queueRequestsCancelled
+                                              + ", blockedActiveDeliveries="
+                                              + result.blockedActiveDeliveries
+                                              + ", assignmentPruned="
+                                              + result.assignmentPruned
+                                              + ", deliveryAssignKicks="
+                                              + result.deliveryAssignKicks
+                                              + ", deliveryRequestsCancelled="
+                                              + result.deliveryRequestsCancelled
+                                              + ", drainRounds="
+                                              + result.drainRounds
+                                              + ", drainResiduals="
+                                              + result.drainResiduals
+                                              + ", errors="
+                                              + result.errors),
+                                  true);
+                          return result.errors == 0 ? 1 : 0;
+                        })));
 
     dispatcher.register(root);
   }
@@ -364,7 +425,7 @@ public final class CreateShopMaintenanceCommands {
     return result;
   }
 
-  private static ResetLiveStateResult resetLiveState() {
+  private static ResetLiveStateResult resetLiveState(boolean forceWarehouseQueueClear) {
     ResetLiveStateResult result = new ResetLiveStateResult();
     for (IColony colony : IColonyManager.getInstance().getAllColonies()) {
       result.colonies++;
@@ -374,6 +435,33 @@ public final class CreateShopMaintenanceCommands {
 
       java.util.Set<BuildingCreateShop> shops = collectCreateShops(colony);
       result.shops += shops.size();
+      int initialActiveLocalDeliveries = countShopsWithActiveLocalDeliveries(colony, shops);
+      int drainRounds = Math.max(1, 3 + (initialActiveLocalDeliveries > 0 ? 1 : 0));
+      result.drainRounds += drainRounds;
+      for (int round = 0; round < drainRounds; round++) {
+        cancelCreateShopOwnedRequestsGraphAware(standard, result);
+        cancelActiveLocalDeliveries(colony, standard, result);
+        reconcileAssignmentsAndKickCouriers(standard, result);
+      }
+
+      // Always prune stale/terminal queue entries; this is conservative and prevents stale
+      // warehouse queue tokens from keeping courier jobs in a stuck loop after request cleanup.
+      clearWarehouseQueues(colony, standard, result);
+      if (forceWarehouseQueueClear) {
+        // Force mode gets one extra prune pass after reconciliation below.
+      }
+
+      int remainingActiveLocalDeliveries = countShopsWithActiveLocalDeliveries(colony, shops);
+      if (forceWarehouseQueueClear) {
+        clearWarehouseQueues(colony, standard, result);
+      }
+      if (remainingActiveLocalDeliveries > 0 || hasActiveCreateShopRootRequests(standard)) {
+        result.blockedActiveDeliveries += remainingActiveLocalDeliveries;
+        result.runtimeTrackingSkipped += shops.size();
+        result.drainResiduals += 1;
+        continue;
+      }
+
       for (BuildingCreateShop shop : shops) {
         try {
           result.runtimeTrackingCleared += Math.max(0, shop.clearRuntimeTrackingForDebug());
@@ -387,56 +475,453 @@ public final class CreateShopMaintenanceCommands {
               ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
         }
       }
+    }
+    return result;
+  }
 
-      java.util.Set<IToken<?>> requestTokens = collectAssignedRequestTokens(standard);
-      for (IToken<?> token : requestTokens) {
+  private static void cancelActiveLocalDeliveries(
+      IColony colony, IStandardRequestManager standard, ResetLiveStateResult result) {
+    if (colony == null || standard == null || result == null) {
+      return;
+    }
+    var store = standard.getRequestResolverRequestAssignmentDataStore();
+    if (store == null || store.getAssignments() == null || store.getAssignments().isEmpty()) {
+      return;
+    }
+    var requestHandler = standard.getRequestHandler();
+    if (requestHandler == null) {
+      return;
+    }
+    java.util.Set<BuildingCreateShop> shops = collectCreateShops(colony);
+    if (shops.isEmpty()) {
+      return;
+    }
+
+    for (var assignmentEntry : store.getAssignments().entrySet()) {
+      var assigned = assignmentEntry.getValue();
+      if (assigned == null || assigned.isEmpty()) {
+        continue;
+      }
+      for (IToken<?> token : java.util.List.copyOf(assigned)) {
+        if (token == null) {
+          continue;
+        }
         try {
-          var request = standard.getRequestHandler().getRequestOrNull(token);
-          if (request == null) {
+          var request = requestHandler.getRequestOrNull(token);
+          if (request == null
+              || !(request.getRequest()
+                  instanceof
+                  com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery)) {
             continue;
           }
-          if (!isCreateShopOwnedRootRequest(standard, request)) {
+          if (isTerminalState(request.getState()) || !isCreateShopOwnedRequest(standard, request)) {
             continue;
           }
-          if (isTerminalState(request.getState())) {
-            if (request.getState() == RequestState.CANCELLED) {
-              standard.getRequestHandler().cleanRequestData(request.getId());
-              result.staleCleaned++;
+          boolean localDeliveryForAnyShop = false;
+          for (BuildingCreateShop shop : shops) {
+            if (shop != null && shop.hasActiveLocalDeliveryChildrenForInflight(colony)) {
+              localDeliveryForAnyShop = true;
+              break;
             }
+          }
+          if (!localDeliveryForAnyShop) {
             continue;
           }
-          standard.updateRequestState(request.getId(), RequestState.CANCELLED);
-          result.requestsCancelled++;
+          standard.updateRequestState(token, RequestState.CANCELLED);
+          result.deliveryRequestsCancelled++;
         } catch (Exception ex) {
           if (isStaleRequestGraphException(ex)) {
-            try {
-              standard.getRequestHandler().cleanRequestData(token);
-              result.staleCleaned++;
-              TheSettlerXCreate.LOGGER.info(
-                  "[CreateShop] reset_live_state stale cleanup token={} reason={}",
-                  token,
-                  ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
-              continue;
-            } catch (Exception cleanEx) {
-              result.errors++;
-              TheSettlerXCreate.LOGGER.warn(
-                  "[CreateShop] reset_live_state stale cleanup failed token={} error={}",
-                  token,
-                  cleanEx.getMessage() == null
-                      ? cleanEx.getClass().getSimpleName()
-                      : cleanEx.getMessage());
-              continue;
-            }
+            continue;
           }
           result.errors++;
           TheSettlerXCreate.LOGGER.warn(
-              "[CreateShop] reset_live_state cancel failed token={} error={}",
+              "[CreateShop] reset_live_state cancel active delivery failed token={} error={}",
               token,
               ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
         }
       }
     }
-    return result;
+  }
+
+  private static int countShopsWithActiveLocalDeliveries(
+      IColony colony, java.util.Set<BuildingCreateShop> shops) {
+    if (colony == null || shops == null || shops.isEmpty()) {
+      return 0;
+    }
+    int active = 0;
+    for (BuildingCreateShop shop : shops) {
+      if (shop == null) {
+        continue;
+      }
+      try {
+        if (shop.hasActiveLocalDeliveryChildrenForInflight(colony)) {
+          active++;
+        }
+      } catch (Exception ex) {
+        // Fail closed: if we cannot verify cleanly, do not perform a destructive cleanup pass.
+        active++;
+        TheSettlerXCreate.LOGGER.warn(
+            "[CreateShop] reset_live_state preflight failed shop={} error={}",
+            shop.getLocation() == null ? "<unknown>" : shop.getLocation().getInDimensionLocation(),
+            ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+      }
+    }
+    return active;
+  }
+
+  private static void reconcileAssignmentsAndKickCouriers(
+      IStandardRequestManager standard, ResetLiveStateResult result) {
+    if (standard == null || result == null) {
+      return;
+    }
+    var store = standard.getRequestResolverRequestAssignmentDataStore();
+    if (store == null || store.getAssignments() == null || store.getAssignments().isEmpty()) {
+      return;
+    }
+    var requestHandler = standard.getRequestHandler();
+    if (requestHandler == null) {
+      return;
+    }
+
+    for (var assignmentEntry : store.getAssignments().entrySet()) {
+      java.util.Collection<IToken<?>> assigned = assignmentEntry.getValue();
+      if (assigned == null || assigned.isEmpty()) {
+        continue;
+      }
+      java.util.Iterator<IToken<?>> iterator = assigned.iterator();
+      while (iterator.hasNext()) {
+        IToken<?> token = iterator.next();
+        if (token == null) {
+          iterator.remove();
+          result.assignmentPruned++;
+          continue;
+        }
+        try {
+          var request = requestHandler.getRequestOrNull(token);
+          if (request == null) {
+            iterator.remove();
+            result.assignmentPruned++;
+            continue;
+          }
+          if (isTerminalState(request.getState())) {
+            iterator.remove();
+            result.assignmentPruned++;
+            continue;
+          }
+          if (!isCreateShopOwnedRequest(standard, request)) {
+            continue;
+          }
+          if (request.getRequest()
+                  instanceof
+                  com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery
+              && request.getState() == RequestState.CREATED) {
+            try {
+              standard.assignRequest(token);
+              result.deliveryAssignKicks++;
+            } catch (Exception kickEx) {
+              result.errors++;
+              TheSettlerXCreate.LOGGER.warn(
+                  "[CreateShop] reset_live_state assign kick failed token={} error={}",
+                  token,
+                  kickEx.getMessage() == null
+                      ? kickEx.getClass().getSimpleName()
+                      : kickEx.getMessage());
+            }
+          }
+        } catch (Exception ex) {
+          if (isStaleRequestGraphException(ex)) {
+            iterator.remove();
+            result.assignmentPruned++;
+            continue;
+          }
+          result.errors++;
+          TheSettlerXCreate.LOGGER.warn(
+              "[CreateShop] reset_live_state reconcile assignment failed token={} error={}",
+              token,
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+    }
+  }
+
+  private static void cancelCreateShopOwnedRequestsGraphAware(
+      IStandardRequestManager standard, ResetLiveStateResult result) {
+    if (standard == null || result == null) {
+      return;
+    }
+    java.util.Set<IToken<?>> assignedTokens = collectAssignedRequestTokens(standard);
+    if (assignedTokens.isEmpty()) {
+      return;
+    }
+
+    java.util.Set<IToken<?>> visited = new java.util.LinkedHashSet<>();
+    java.util.List<IToken<?>> roots = new java.util.ArrayList<>();
+    for (IToken<?> token : assignedTokens) {
+      if (token == null) {
+        continue;
+      }
+      try {
+        var request = standard.getRequestHandler().getRequestOrNull(token);
+        if (request == null || !isCreateShopOwnedRootRequest(standard, request)) {
+          continue;
+        }
+        roots.add(token);
+      } catch (Exception ex) {
+        if (isStaleRequestGraphException(ex)) {
+          cleanupStaleToken(standard, token, result, "reset_live_state root scan");
+        } else {
+          result.errors++;
+          TheSettlerXCreate.LOGGER.warn(
+              "[CreateShop] reset_live_state root scan failed token={} error={}",
+              token,
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+    }
+
+    for (IToken<?> root : roots) {
+      cancelRequestGraphPostOrder(standard, root, visited, result);
+    }
+
+    // Cancel orphaned assigned Create Shop requests that are not reachable from a root graph.
+    for (IToken<?> token : assignedTokens) {
+      if (token == null || visited.contains(token)) {
+        continue;
+      }
+      try {
+        var request = standard.getRequestHandler().getRequestOrNull(token);
+        if (request == null || !isCreateShopOwnedRequest(standard, request)) {
+          continue;
+        }
+        cancelSingleRequest(standard, request, result);
+      } catch (Exception ex) {
+        if (isStaleRequestGraphException(ex)) {
+          cleanupStaleToken(standard, token, result, "reset_live_state orphan scan");
+        } else {
+          result.errors++;
+          TheSettlerXCreate.LOGGER.warn(
+              "[CreateShop] reset_live_state orphan scan failed token={} error={}",
+              token,
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+    }
+  }
+
+  private static void cancelRequestGraphPostOrder(
+      IStandardRequestManager standard,
+      IToken<?> token,
+      java.util.Set<IToken<?>> visited,
+      ResetLiveStateResult result) {
+    if (standard == null || token == null || visited == null || result == null) {
+      return;
+    }
+    if (!visited.add(token)) {
+      return;
+    }
+
+    com.minecolonies.api.colony.requestsystem.request.IRequest<?> request;
+    try {
+      request = standard.getRequestHandler().getRequestOrNull(token);
+    } catch (Exception ex) {
+      if (isStaleRequestGraphException(ex)) {
+        cleanupStaleToken(standard, token, result, "reset_live_state graph fetch");
+      } else {
+        result.errors++;
+        TheSettlerXCreate.LOGGER.warn(
+            "[CreateShop] reset_live_state graph fetch failed token={} error={}",
+            token,
+            ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+      }
+      return;
+    }
+
+    if (request == null) {
+      cleanupStaleToken(standard, token, result, "reset_live_state graph missing");
+      return;
+    }
+
+    if (request.hasChildren()
+        && request.getChildren() != null
+        && !request.getChildren().isEmpty()) {
+      for (IToken<?> child : java.util.List.copyOf(request.getChildren())) {
+        cancelRequestGraphPostOrder(standard, child, visited, result);
+      }
+    }
+
+    cancelSingleRequest(standard, request, result);
+  }
+
+  private static void cancelSingleRequest(
+      IStandardRequestManager standard,
+      com.minecolonies.api.colony.requestsystem.request.IRequest<?> request,
+      ResetLiveStateResult result) {
+    if (standard == null || request == null || result == null) {
+      return;
+    }
+    try {
+      if (isTerminalState(request.getState())) {
+        if (request.getState() == RequestState.CANCELLED) {
+          standard.getRequestHandler().cleanRequestData(request.getId());
+          result.staleCleaned++;
+        }
+        return;
+      }
+      standard.updateRequestState(request.getId(), RequestState.CANCELLED);
+      result.requestsCancelled++;
+    } catch (Exception ex) {
+      if (isStaleRequestGraphException(ex)) {
+        cleanupStaleToken(standard, request.getId(), result, "reset_live_state graph cancel");
+        return;
+      }
+      result.errors++;
+      TheSettlerXCreate.LOGGER.warn(
+          "[CreateShop] reset_live_state cancel failed token={} error={}",
+          request.getId(),
+          ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+    }
+  }
+
+  private static void cleanupStaleToken(
+      IStandardRequestManager standard,
+      IToken<?> token,
+      ResetLiveStateResult result,
+      String reason) {
+    if (standard == null || token == null || result == null) {
+      return;
+    }
+    try {
+      standard.getRequestHandler().cleanRequestData(token);
+      result.staleCleaned++;
+      TheSettlerXCreate.LOGGER.info("[CreateShop] {} stale cleanup token={}", reason, token);
+    } catch (Exception cleanEx) {
+      result.errors++;
+      TheSettlerXCreate.LOGGER.warn(
+          "[CreateShop] {} stale cleanup failed token={} error={}",
+          reason,
+          token,
+          cleanEx.getMessage() == null ? cleanEx.getClass().getSimpleName() : cleanEx.getMessage());
+    }
+  }
+
+  private static void clearWarehouseQueues(
+      IColony colony, IStandardRequestManager standard, ResetLiveStateResult result) {
+    if (colony == null || standard == null || result == null) {
+      return;
+    }
+    var buildingManager = colony.getServerBuildingManager();
+    if (buildingManager == null || buildingManager.getBuildings() == null) {
+      return;
+    }
+    for (var entry : buildingManager.getBuildings().entrySet()) {
+      var building = entry.getValue();
+      if (building == null) {
+        continue;
+      }
+      var queue =
+          building.getModule(
+              com.minecolonies.core.colony.buildings.modules.BuildingModules
+                  .WAREHOUSE_REQUEST_QUEUE);
+      if (queue == null
+          || queue.getMutableRequestList() == null
+          || queue.getMutableRequestList().isEmpty()) {
+        continue;
+      }
+      java.util.Iterator<IToken<?>> iterator = queue.getMutableRequestList().iterator();
+      while (iterator.hasNext()) {
+        IToken<?> queuedToken = iterator.next();
+        if (queuedToken == null) {
+          iterator.remove();
+          result.queueEntriesCleared++;
+          continue;
+        }
+        try {
+          var queuedRequest = standard.getRequestHandler().getRequestOrNull(queuedToken);
+          if (queuedRequest == null) {
+            iterator.remove();
+            result.queueEntriesCleared++;
+            result.staleCleaned++;
+            continue;
+          }
+          if (!isTerminalState(queuedRequest.getState())) {
+            // Reset should leave no active Create Shop queue residue behind.
+            if (!isCreateShopOwnedRequest(standard, queuedRequest)) {
+              continue;
+            }
+            try {
+              standard.updateRequestState(queuedToken, RequestState.CANCELLED);
+              result.queueRequestsCancelled++;
+            } catch (Exception cancelEx) {
+              if (!isStaleRequestGraphException(cancelEx)) {
+                result.errors++;
+                TheSettlerXCreate.LOGGER.warn(
+                    "[CreateShop] reset_live_state queue active cancel failed token={} error={}",
+                    queuedToken,
+                    cancelEx.getMessage() == null
+                        ? cancelEx.getClass().getSimpleName()
+                        : cancelEx.getMessage());
+              }
+            }
+            iterator.remove();
+            result.queueEntriesCleared++;
+            try {
+              standard.getRequestHandler().cleanRequestData(queuedToken);
+              result.staleCleaned++;
+            } catch (Exception cleanEx) {
+              if (!isStaleRequestGraphException(cleanEx)) {
+                result.errors++;
+                TheSettlerXCreate.LOGGER.warn(
+                    "[CreateShop] reset_live_state queue active cleanup failed token={} error={}",
+                    queuedToken,
+                    cleanEx.getMessage() == null
+                        ? cleanEx.getClass().getSimpleName()
+                        : cleanEx.getMessage());
+              }
+            }
+            continue;
+          }
+          iterator.remove();
+          result.queueEntriesCleared++;
+          if (queuedRequest.getState() == RequestState.CANCELLED) {
+            try {
+              standard.getRequestHandler().cleanRequestData(queuedToken);
+              result.staleCleaned++;
+            } catch (Exception cleanEx) {
+              result.errors++;
+              TheSettlerXCreate.LOGGER.warn(
+                  "[CreateShop] reset_live_state queue stale cleanup failed token={} error={}",
+                  queuedToken,
+                  cleanEx.getMessage() == null
+                      ? cleanEx.getClass().getSimpleName()
+                      : cleanEx.getMessage());
+            }
+          }
+        } catch (Exception ex) {
+          if (isStaleRequestGraphException(ex)) {
+            iterator.remove();
+            result.queueEntriesCleared++;
+            try {
+              standard.getRequestHandler().cleanRequestData(queuedToken);
+              result.staleCleaned++;
+            } catch (Exception cleanEx) {
+              result.errors++;
+              TheSettlerXCreate.LOGGER.warn(
+                  "[CreateShop] reset_live_state queue stale cleanup failed token={} error={}",
+                  queuedToken,
+                  cleanEx.getMessage() == null
+                      ? cleanEx.getClass().getSimpleName()
+                      : cleanEx.getMessage());
+            }
+            continue;
+          }
+          result.errors++;
+          TheSettlerXCreate.LOGGER.warn(
+              "[CreateShop] reset_live_state queue cancel failed token={} error={}",
+              queuedToken,
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+    }
   }
 
   private static java.util.Set<BuildingCreateShop> collectCreateShops(IColony colony) {
@@ -509,6 +994,31 @@ public final class CreateShopMaintenanceCommands {
     return request != null && !request.hasParent();
   }
 
+  private static boolean hasActiveCreateShopRootRequests(IStandardRequestManager standard) {
+    if (standard == null) {
+      return false;
+    }
+    java.util.Set<IToken<?>> tokens = collectAssignedRequestTokens(standard);
+    for (IToken<?> token : tokens) {
+      if (token == null) {
+        continue;
+      }
+      try {
+        var request = standard.getRequestHandler().getRequestOrNull(token);
+        if (request == null || !isCreateShopOwnedRootRequest(standard, request)) {
+          continue;
+        }
+        if (!isTerminalState(request.getState())) {
+          return true;
+        }
+      } catch (Exception ignored) {
+        // Fail open: keep runtime tracking when assignment graph is unstable.
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static boolean isTerminalState(RequestState state) {
     return state == RequestState.CANCELLED
         || state == RequestState.COMPLETED
@@ -556,6 +1066,15 @@ public final class CreateShopMaintenanceCommands {
     int requestsCancelled;
     int staleCleaned;
     int runtimeTrackingCleared;
+    int runtimeTrackingSkipped;
+    int queueEntriesCleared;
+    int queueRequestsCancelled;
+    int blockedActiveDeliveries;
+    int assignmentPruned;
+    int deliveryAssignKicks;
+    int deliveryRequestsCancelled;
+    int drainRounds;
+    int drainResiduals;
     int errors;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
@@ -80,6 +80,32 @@ public final class CreateShopMaintenanceCommands {
                                         IntegerArgumentType.getInteger(context, "requests"),
                                         IntegerArgumentType.getInteger(context, "amount"))))));
 
+    root.then(
+        Commands.literal("reset_live_state")
+            .executes(
+                context -> {
+                  ResetLiveStateResult result = resetLiveState();
+                  context
+                      .getSource()
+                      .sendSuccess(
+                          () ->
+                              Component.literal(
+                                  "[CreateShop] Live state reset: colonies="
+                                      + result.colonies
+                                      + ", shops="
+                                      + result.shops
+                                      + ", requestsCancelled="
+                                      + result.requestsCancelled
+                                      + ", staleCleaned="
+                                      + result.staleCleaned
+                                      + ", runtimeTrackingCleared="
+                                      + result.runtimeTrackingCleared
+                                      + ", errors="
+                                      + result.errors),
+                          true);
+                  return result.errors == 0 ? 1 : 0;
+                }));
+
     dispatcher.register(root);
   }
 
@@ -338,6 +364,176 @@ public final class CreateShopMaintenanceCommands {
     return result;
   }
 
+  private static ResetLiveStateResult resetLiveState() {
+    ResetLiveStateResult result = new ResetLiveStateResult();
+    for (IColony colony : IColonyManager.getInstance().getAllColonies()) {
+      result.colonies++;
+      if (!(colony.getRequestManager() instanceof IStandardRequestManager standard)) {
+        continue;
+      }
+
+      java.util.Set<BuildingCreateShop> shops = collectCreateShops(colony);
+      result.shops += shops.size();
+      for (BuildingCreateShop shop : shops) {
+        try {
+          result.runtimeTrackingCleared += Math.max(0, shop.clearRuntimeTrackingForDebug());
+        } catch (Exception ex) {
+          result.errors++;
+          TheSettlerXCreate.LOGGER.warn(
+              "[CreateShop] reset_live_state tracking clear failed shop={} error={}",
+              shop.getLocation() == null
+                  ? "<unknown>"
+                  : shop.getLocation().getInDimensionLocation(),
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+
+      java.util.Set<IToken<?>> requestTokens = collectAssignedRequestTokens(standard);
+      for (IToken<?> token : requestTokens) {
+        try {
+          var request = standard.getRequestHandler().getRequestOrNull(token);
+          if (request == null) {
+            continue;
+          }
+          if (!isCreateShopOwnedRootRequest(standard, request)) {
+            continue;
+          }
+          if (isTerminalState(request.getState())) {
+            if (request.getState() == RequestState.CANCELLED) {
+              standard.getRequestHandler().cleanRequestData(request.getId());
+              result.staleCleaned++;
+            }
+            continue;
+          }
+          standard.updateRequestState(request.getId(), RequestState.CANCELLED);
+          result.requestsCancelled++;
+        } catch (Exception ex) {
+          if (isStaleRequestGraphException(ex)) {
+            try {
+              standard.getRequestHandler().cleanRequestData(token);
+              result.staleCleaned++;
+              TheSettlerXCreate.LOGGER.info(
+                  "[CreateShop] reset_live_state stale cleanup token={} reason={}",
+                  token,
+                  ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+              continue;
+            } catch (Exception cleanEx) {
+              result.errors++;
+              TheSettlerXCreate.LOGGER.warn(
+                  "[CreateShop] reset_live_state stale cleanup failed token={} error={}",
+                  token,
+                  cleanEx.getMessage() == null
+                      ? cleanEx.getClass().getSimpleName()
+                      : cleanEx.getMessage());
+              continue;
+            }
+          }
+          result.errors++;
+          TheSettlerXCreate.LOGGER.warn(
+              "[CreateShop] reset_live_state cancel failed token={} error={}",
+              token,
+              ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        }
+      }
+    }
+    return result;
+  }
+
+  private static java.util.Set<BuildingCreateShop> collectCreateShops(IColony colony) {
+    java.util.Set<BuildingCreateShop> shops = new java.util.LinkedHashSet<>();
+    if (colony == null) {
+      return shops;
+    }
+    var buildingManager = colony.getServerBuildingManager();
+    if (buildingManager == null || buildingManager.getBuildings() == null) {
+      return shops;
+    }
+    for (var entry : buildingManager.getBuildings().entrySet()) {
+      var building = entry.getValue();
+      if (building instanceof BuildingCreateShop shop) {
+        shops.add(shop);
+      }
+    }
+    return shops;
+  }
+
+  private static java.util.Set<IToken<?>> collectAssignedRequestTokens(
+      IStandardRequestManager standard) {
+    java.util.Set<IToken<?>> tokens = new java.util.LinkedHashSet<>();
+    if (standard == null) {
+      return tokens;
+    }
+    var assignments = standard.getRequestResolverRequestAssignmentDataStore().getAssignments();
+    if (assignments == null || assignments.isEmpty()) {
+      return tokens;
+    }
+    for (var assigned : assignments.values()) {
+      if (assigned != null) {
+        tokens.addAll(assigned);
+      }
+    }
+    return tokens;
+  }
+
+  private static boolean isCreateShopOwnedRequest(
+      IStandardRequestManager standard,
+      com.minecolonies.api.colony.requestsystem.request.IRequest<?> request) {
+    if (standard == null || request == null) {
+      return false;
+    }
+    try {
+      var owner = standard.getResolverHandler().getResolverForRequest(request);
+      if (owner instanceof CreateShopRequestResolver) {
+        return true;
+      }
+      if (!request.hasParent()) {
+        return false;
+      }
+      var parent = standard.getRequestHandler().getRequest(request.getParent());
+      if (parent == null) {
+        return false;
+      }
+      var parentOwner = standard.getResolverHandler().getResolverForRequest(parent);
+      return parentOwner instanceof CreateShopRequestResolver;
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  private static boolean isCreateShopOwnedRootRequest(
+      IStandardRequestManager standard,
+      com.minecolonies.api.colony.requestsystem.request.IRequest<?> request) {
+    if (!isCreateShopOwnedRequest(standard, request)) {
+      return false;
+    }
+    return request != null && !request.hasParent();
+  }
+
+  private static boolean isTerminalState(RequestState state) {
+    return state == RequestState.CANCELLED
+        || state == RequestState.COMPLETED
+        || state == RequestState.FAILED
+        || state == RequestState.RECEIVED
+        || state == RequestState.RESOLVED;
+  }
+
+  private static boolean isStaleRequestGraphException(Exception ex) {
+    if (ex == null) {
+      return false;
+    }
+    String message = ex.getMessage();
+    if (message == null || message.isEmpty()) {
+      return false;
+    }
+    String normalized = message.toLowerCase(java.util.Locale.ROOT);
+    boolean staleChildren =
+        normalized.contains("haschildren()")
+            && normalized.contains("request")
+            && normalized.contains("null");
+    boolean assignmentDrift = normalized.contains("intvalue()");
+    return staleChildren || assignmentDrift;
+  }
+
   private static final class Result {
     int colonies;
     int shops;
@@ -352,5 +548,14 @@ public final class CreateShopMaintenanceCommands {
     int created;
     int errors;
     String message = "";
+  }
+
+  private static final class ResetLiveStateResult {
+    int colonies;
+    int shops;
+    int requestsCancelled;
+    int staleCleaned;
+    int runtimeTrackingCleared;
+    int errors;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
@@ -23,6 +23,7 @@ import com.minecolonies.core.colony.requestsystem.resolvers.core.AbstractWarehou
 import com.thesettler_x_create.Config;
 import com.thesettler_x_create.TheSettlerXCreate;
 import com.thesettler_x_create.blockentity.CreateShopBlockEntity;
+import com.thesettler_x_create.minecolonies.building.BuildingCreateShop;
 import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
@@ -385,6 +386,11 @@ final class CreateShopDeliveryManager {
     int warehousesWithCouriers = 0;
     int warehousesWithQueue = 0;
     for (var entry : buildingManager.getBuildings().entrySet()) {
+      if (entry.getValue() instanceof BuildingCreateShop) {
+        // The shop is IRequester/IWareHouse for MineColonies integration, but must never be used as
+        // a deliveryman source.
+        continue;
+      }
       if (!(entry.getValue() instanceof IWareHouse warehouse)) {
         continue;
       }
@@ -458,6 +464,10 @@ final class CreateShopDeliveryManager {
     for (var entry : buildingManager.getBuildings().entrySet()) {
       var building = entry.getValue();
       if (building == null) {
+        continue;
+      }
+      if (building instanceof BuildingCreateShop) {
+        // Never treat the Create Shop worker as courier.
         continue;
       }
       CourierAssignmentModule warehouseCouriers =

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryState.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryState.java
@@ -3,6 +3,7 @@ package com.thesettler_x_create.minecolonies.requestsystem.resolver;
 final class CreateShopPendingDeliveryState {
   private int pendingCount;
   private boolean deliveryCreated;
+  private boolean deliveryStarted;
   private long cooldownUntil;
   private String reason;
 
@@ -20,6 +21,14 @@ final class CreateShopPendingDeliveryState {
 
   void setDeliveryCreated(boolean deliveryCreated) {
     this.deliveryCreated = deliveryCreated;
+  }
+
+  boolean isDeliveryStarted() {
+    return deliveryStarted;
+  }
+
+  void setDeliveryStarted(boolean deliveryStarted) {
+    this.deliveryStarted = deliveryStarted;
   }
 
   long getCooldownUntil() {

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryTracker.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryTracker.java
@@ -82,6 +82,7 @@ final class CreateShopPendingDeliveryTracker {
   void markDeliveryCreated(IToken<?> token) {
     CreateShopPendingDeliveryState state = getOrCreate(token);
     state.setDeliveryCreated(true);
+    state.setDeliveryStarted(true);
   }
 
   void clearDeliveryCreated(IToken<?> token) {
@@ -90,6 +91,11 @@ final class CreateShopPendingDeliveryTracker {
       state.setDeliveryCreated(false);
       pruneIfEmpty(token, state);
     }
+  }
+
+  boolean hasDeliveryStarted(IToken<?> token) {
+    CreateShopPendingDeliveryState state = pending.getIfPresent(token);
+    return state != null && state.isDeliveryStarted();
   }
 
   void setReason(IToken<?> token, String reason) {
@@ -115,6 +121,7 @@ final class CreateShopPendingDeliveryTracker {
     }
     return state.getPendingCount() > 0
         || state.isDeliveryCreated()
+        || state.isDeliveryStarted()
         || state.getCooldownUntil() > 0L;
   }
 
@@ -132,6 +139,7 @@ final class CreateShopPendingDeliveryTracker {
     }
     if (state.getPendingCount() <= 0
         && !state.isDeliveryCreated()
+        && !state.isDeliveryStarted()
         && state.getCooldownUntil() <= 0L) {
       pending.invalidate(token);
     }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -1617,7 +1617,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
         String requesterName = messaging.resolveRequesterName(manager, request);
         TileEntityCreateShop tile = shop.getCreateShopTileEntity();
         String address = sanitizeAddress(tile == null ? "" : tile.getShopAddress());
-        int cleared = shop.cancelLostPackage(key, requesterName, address);
+        int cleared = shop.cancelLostPackage(key, requesterName, address, -1L);
         if (Config.DEBUG_LOGGING.getAsBoolean()) {
           TheSettlerXCreate.LOGGER.info(
               "[CreateShop] releaseReservation cancelled request={} item={} requester='{}' address='{}' clearedInflight={}",

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.INonExhaustiveDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
@@ -65,9 +66,21 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap<>());
   private final java.util.Map<IToken<?>, Long> deliveryChildActiveSince =
       new java.util.concurrent.ConcurrentHashMap<>();
+  private final java.util.Map<IToken<?>, Long> missingChildSince =
+      new java.util.concurrent.ConcurrentHashMap<>();
   private final java.util.Map<IToken<?>, Long> parentDeliveryActiveSince =
       new java.util.concurrent.ConcurrentHashMap<>();
   private final java.util.Map<IToken<?>, Long> parentStaleRecoveryArmedAt =
+      new java.util.concurrent.ConcurrentHashMap<>();
+  private final java.util.Map<IToken<?>, Integer> parentLastKnownChildCount =
+      new java.util.concurrent.ConcurrentHashMap<>();
+  private final java.util.Map<IToken<?>, String> parentLastKnownChildren =
+      new java.util.concurrent.ConcurrentHashMap<>();
+  private final java.util.Map<IToken<?>, Long> parentChildDropLastLogTick =
+      new java.util.concurrent.ConcurrentHashMap<>();
+  private final java.util.Map<IToken<?>, String> deliveryRootCauseSnapshots =
+      new java.util.concurrent.ConcurrentHashMap<>();
+  private final java.util.Map<IToken<?>, Long> deliveryRootCauseLastLogTick =
       new java.util.concurrent.ConcurrentHashMap<>();
   private final CreateShopResolverPlanning planning = new CreateShopResolverPlanning();
   private final CreateShopDeliveryManager deliveryManager = new CreateShopDeliveryManager(this);
@@ -153,6 +166,15 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       }
       return Lists.newArrayList();
     }
+    if (request.hasChildren()) {
+      flowStateMachine.touch(request.getId(), now, "attemptResolve:has-children");
+      if (Config.DEBUG_LOGGING.getAsBoolean()) {
+        TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] attemptResolve skipped (has active children) request={}",
+            request.getId());
+      }
+      return Lists.newArrayList();
+    }
     if (hasDeliveriesCreated(request.getId())) {
       flowStateMachine.touch(request.getId(), now, "attemptResolve:deliveries-created");
       return Lists.newArrayList();
@@ -193,6 +215,20 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     UUID requestId = toRequestId(request.getId());
     int reservedForRequest = pickup.getReservedForRequest(requestId);
     int needed = computeOutstandingNeeded(request, deliverable, reservedForRequest);
+    if (needed > 0 && pendingTracker.hasDeliveryStarted(request.getId())) {
+      cooldown.markRequestOrdered(level, request.getId());
+      pendingTracker.setPendingCount(request.getId(), Math.max(1, needed));
+      diagnostics.recordPendingSource(request.getId(), "attemptResolve:block-auto-reorder-started");
+      flowStateMachine.touch(request.getId(), now, "attemptResolve:block-auto-reorder-started");
+      if (Config.DEBUG_LOGGING.getAsBoolean()) {
+        TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] attemptResolve blocked auto-reorder (started-order) request={} needed={} reserved={}",
+            request.getId(),
+            needed,
+            reservedForRequest);
+      }
+      return Lists.newArrayList();
+    }
     int reservedForDeliverable = pickup.getReservedForDeliverable(deliverable);
     int reservedForOthers = Math.max(0, reservedForDeliverable - reservedForRequest);
     if (needed <= 0) {
@@ -578,6 +614,20 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
         }
         continue;
       }
+      if (isTerminalRequestState(request.getState())) {
+        cooldown.clearRequestCooldown(request.getId());
+        pendingTracker.remove(request.getId());
+        clearDeliveriesCreated(request.getId());
+        flowStateMachine.remove(request.getId());
+        diagnostics.logPendingReasonChange(request.getId(), "skip:terminal-state");
+        if (Config.DEBUG_LOGGING.getAsBoolean()) {
+          TheSettlerXCreate.LOGGER.info(
+              "[CreateShop] tickPending: {} skip (terminal state={})",
+              request.getId(),
+              request.getState());
+        }
+        continue;
+      }
       diagnostics.logRequestStateChange(standardManager, token, "tickPending");
       if (!(request.getRequest() instanceof IDeliverable deliverable)) {
         diagnostics.logPendingReasonChange(token, "skip:not-deliverable");
@@ -591,6 +641,8 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
         diagnostics.logPendingReasonChange(request.getId(), "skip:has-children");
         java.util.Collection<IToken<?>> children =
             java.util.Objects.requireNonNull(request.getChildren(), "children");
+        parentLastKnownChildCount.put(request.getId(), children.size());
+        parentLastKnownChildren.put(request.getId(), children.toString());
         int missing = 0;
         int duplicateChildrenRemoved = 0;
         boolean hasActiveChildren = false;
@@ -612,15 +664,28 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             try {
               IRequest<?> child = requestHandler.getRequest(childToken);
               if (child == null) {
-                hasActiveChildren = true;
-                if (Config.DEBUG_LOGGING.getAsBoolean()) {
-                  TheSettlerXCreate.LOGGER.info(
-                      "[CreateShop] tickPending: {} child {} missing -> keep (fail-open)",
-                      requestIdLog,
-                      childToken);
+                if (shouldDropMissingChild(level, childToken)) {
+                  request.removeChild(childToken);
+                  missingChildSince.remove(childToken);
+                  missing++;
+                  if (Config.DEBUG_LOGGING.getAsBoolean()) {
+                    TheSettlerXCreate.LOGGER.info(
+                        "[CreateShop] tickPending: {} child {} missing -> dropped after grace",
+                        requestIdLog,
+                        childToken);
+                  }
+                } else {
+                  hasActiveChildren = true;
+                  if (Config.DEBUG_LOGGING.getAsBoolean()) {
+                    TheSettlerXCreate.LOGGER.info(
+                        "[CreateShop] tickPending: {} child {} missing -> keep (fail-open) grace",
+                        requestIdLog,
+                        childToken);
+                  }
                 }
                 continue;
               }
+              missingChildSince.remove(childToken);
               if (child != null
                   && child.getRequest()
                       instanceof
@@ -644,6 +709,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
                 if (terminalChild) {
                   request.removeChild(childToken);
                   deliveryChildActiveSince.remove(childToken);
+                  missingChildSince.remove(childToken);
                   clearStaleRecoveryArm(request.getId());
                   continue;
                 }
@@ -714,6 +780,8 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
                 } else {
                   clearStaleRecoveryArm(request.getId());
                 }
+                logDeliveryRootCauseSnapshot(
+                    standardManager, level, request, child, childToken, childAssigned);
                 hasActiveChildren = true;
               } else {
                 deliveryChildActiveSince.remove(childToken);
@@ -780,6 +848,28 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
           continue;
         }
       }
+      Integer previousChildCount = parentLastKnownChildCount.get(request.getId());
+      if (previousChildCount != null && previousChildCount > 0 && !request.hasChildren()) {
+        long now = level.getGameTime();
+        Long lastDropLog = parentChildDropLastLogTick.get(request.getId());
+        if (lastDropLog == null || now - lastDropLog >= 100L) {
+          parentChildDropLastLogTick.put(request.getId(), now);
+          if (Config.DEBUG_LOGGING.getAsBoolean()) {
+            String previousChildren = parentLastKnownChildren.getOrDefault(request.getId(), "[]");
+            TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] root-cause parent-child-drop parent={} state={} prevChildCount={} prevChildren={} reservedForRequest={} pending={} cooldown={}",
+                request.getId(),
+                request.getState(),
+                previousChildCount,
+                previousChildren,
+                reservedForRequest,
+                pendingTracker.getPendingCount(request.getId()),
+                cooldown.isRequestOnCooldown(level, request.getId()));
+          }
+        }
+      }
+      parentLastKnownChildCount.put(request.getId(), 0);
+      parentLastKnownChildren.put(request.getId(), "[]");
       parentDeliveryActiveSince.remove(request.getId());
       clearStaleRecoveryArm(request.getId());
       if (hasDeliveriesCreated(request.getId())) {
@@ -863,6 +953,12 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
         continue;
       }
       int rackAvailable = planning.getAvailableFromRacks(tile, deliverable);
+      int reservedForDeliverable = pickup.getReservedForDeliverable(deliverable);
+      int rackAvailableForRequest =
+          Math.max(
+              0,
+              rackAvailable
+                  - Math.max(0, reservedForDeliverable - Math.max(0, reservedForRequest)));
       int reservedSynced =
           syncReservationsFromRack(
               tile,
@@ -872,59 +968,91 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
               deliverable,
               pendingCount,
               reservedForRequest,
-              rackAvailable,
+              rackAvailableForRequest,
               level.getGameTime());
       if (reservedSynced > 0) {
         reservedForRequest += reservedSynced;
+        reservedForDeliverable += reservedSynced;
+        rackAvailableForRequest =
+            Math.max(
+                0,
+                rackAvailable
+                    - Math.max(0, reservedForDeliverable - Math.max(0, reservedForRequest)));
       }
       int topupNeeded =
-          Math.max(0, pendingCount - Math.max(0, reservedForRequest) - Math.max(0, rackAvailable));
+          Math.max(
+              0,
+              pendingCount
+                  - Math.max(0, reservedForRequest)
+                  - Math.max(0, rackAvailableForRequest));
+      // Guard anchor: legacy topup baseline is "pending - reserved - rackAvailable"
+      // i.e. "- Math.max(0, rackAvailable)" before exclusive reservation refinement.
       if (workerWorking && topupNeeded > 0) {
-        String requesterName = messaging.resolveRequesterName(manager, request);
-        int inflightRemaining =
-            pickup.getInflightRemaining(
-                deliverable.getResult(), requesterName, tile.getShopAddress());
-        if (inflightRemaining > 0) {
+        if (pendingTracker.hasDeliveryStarted(request.getId())) {
           cooldown.markRequestOrdered(level, request.getId());
           pendingTracker.setPendingCount(request.getId(), pendingCount);
-          diagnostics.recordPendingSource(request.getId(), "tickPending:wait-inflight");
-          flowStateMachine.touch(request.getId(), level.getGameTime(), "tickPending:wait-inflight");
+          diagnostics.recordPendingSource(
+              request.getId(), "tickPending:block-auto-reorder-started");
+          flowStateMachine.touch(
+              request.getId(), level.getGameTime(), "tickPending:block-auto-reorder-started");
           if (Config.DEBUG_LOGGING.getAsBoolean()) {
             TheSettlerXCreate.LOGGER.info(
-                "[CreateShop] tickPending: {} network topup blocked (inflightRemaining={}, pending={}, reserved={}, rack={})",
+                "[CreateShop] tickPending: {} network topup blocked (started-order, pending={}, reserved={}, rack={})",
                 requestIdLog,
-                inflightRemaining,
                 pendingCount,
                 reservedForRequest,
-                rackAvailable);
+                rackAvailableForRequest);
           }
         } else {
-          int networkAvailable = stockResolver.getNetworkAvailable(tile, deliverable);
-          int topupCount = Math.min(networkAvailable, topupNeeded);
-          if (topupCount > 0) {
-            List<ItemStack> topupOrdered =
-                stockResolver.requestFromNetwork(tile, deliverable, topupCount, requesterName);
-            if (!topupOrdered.isEmpty()) {
-              for (ItemStack stack : topupOrdered) {
-                if (stack.isEmpty()) {
-                  continue;
+          String requesterName = messaging.resolveRequesterName(manager, request);
+          int inflightRemaining =
+              pickup.getInflightRemaining(
+                  deliverable.getResult(), requesterName, tile.getShopAddress());
+          if (inflightRemaining > 0) {
+            cooldown.markRequestOrdered(level, request.getId());
+            pendingTracker.setPendingCount(request.getId(), pendingCount);
+            diagnostics.recordPendingSource(request.getId(), "tickPending:wait-inflight");
+            flowStateMachine.touch(
+                request.getId(), level.getGameTime(), "tickPending:wait-inflight");
+            if (Config.DEBUG_LOGGING.getAsBoolean()) {
+              TheSettlerXCreate.LOGGER.info(
+                  "[CreateShop] tickPending: {} network topup blocked (inflightRemaining={}, pending={}, reserved={}, rack={})",
+                  requestIdLog,
+                  inflightRemaining,
+                  pendingCount,
+                  reservedForRequest,
+                  rackAvailableForRequest);
+            }
+          } else {
+            int networkAvailable = stockResolver.getNetworkAvailable(tile, deliverable);
+            int topupCount = Math.min(networkAvailable, topupNeeded);
+            if (topupCount > 0) {
+              List<ItemStack> topupOrdered =
+                  stockResolver.requestFromNetwork(tile, deliverable, topupCount, requesterName);
+              if (!topupOrdered.isEmpty()) {
+                for (ItemStack stack : topupOrdered) {
+                  if (stack.isEmpty()) {
+                    continue;
+                  }
+                  pickup.reserve(requestId, stack.copy(), stack.getCount());
                 }
-                pickup.reserve(requestId, stack.copy(), stack.getCount());
-              }
-              cooldown.markRequestOrdered(level, request.getId());
-              pendingTracker.setPendingCount(request.getId(), pendingCount);
-              diagnostics.recordPendingSource(request.getId(), "tickPending:network-topup");
-              flowStateMachine.touch(
-                  request.getId(), level.getGameTime(), "tickPending:network-topup");
-              messaging.sendShopChat(
-                  manager, "com.thesettler_x_create.message.createshop.request_sent", topupOrdered);
-              if (Config.DEBUG_LOGGING.getAsBoolean()) {
-                TheSettlerXCreate.LOGGER.info(
-                    "[CreateShop] tickPending: {} network topup ordered={} pending={} reserved={}",
-                    requestIdLog,
-                    countStackList(topupOrdered),
-                    pendingCount,
-                    reservedForRequest);
+                cooldown.markRequestOrdered(level, request.getId());
+                pendingTracker.setPendingCount(request.getId(), pendingCount);
+                diagnostics.recordPendingSource(request.getId(), "tickPending:network-topup");
+                flowStateMachine.touch(
+                    request.getId(), level.getGameTime(), "tickPending:network-topup");
+                messaging.sendShopChat(
+                    manager,
+                    "com.thesettler_x_create.message.createshop.request_sent",
+                    topupOrdered);
+                if (Config.DEBUG_LOGGING.getAsBoolean()) {
+                  TheSettlerXCreate.LOGGER.info(
+                      "[CreateShop] tickPending: {} network topup ordered={} pending={} reserved={}",
+                      requestIdLog,
+                      countStackList(topupOrdered),
+                      pendingCount,
+                      reservedForRequest);
+                }
               }
             }
           }
@@ -934,7 +1062,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             request.getId(), level.getGameTime(), "tickPending:worker-idle-topup");
         diagnostics.logPendingReasonChange(request.getId(), "wait:worker-for-network-topup");
       }
-      int totalAvailable = rackAvailable;
+      int totalAvailable = rackAvailableForRequest;
       if (totalAvailable <= 0) {
         flowStateMachine.touch(request.getId(), level.getGameTime(), "tickPending:waiting-arrival");
         diagnostics.logPendingReasonChange(
@@ -942,7 +1070,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             "wait:available="
                 + totalAvailable
                 + " rack="
-                + rackAvailable
+                + rackAvailableForRequest
                 + " pending="
                 + pendingCount);
         if (pendingState.shouldNotifyPending(level, request.getId())) {
@@ -956,7 +1084,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
               "[CreateShop] tickPending: {} waiting (available={}, rackAvailable={}, pendingCount={})",
               requestIdLog,
               totalAvailable,
-              rackAvailable,
+              rackAvailableForRequest,
               pendingCount);
         }
         continue;
@@ -971,7 +1099,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
           TheSettlerXCreate.LOGGER.info(
               "[CreateShop] tickPending: {} skip (plan empty, rackAvailable={}, pendingCount={})",
               requestIdLog,
-              rackAvailable,
+              rackAvailableForRequest,
               pendingCount);
         }
         continue;
@@ -983,7 +1111,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
             stacks.size(),
             deliverCount,
             pendingCount,
-            rackAvailable);
+            rackAvailableForRequest);
       }
       List<IToken<?>> created =
           deliveryManager.createDeliveriesFromStacks(manager, request, stacks, pickup);
@@ -1023,8 +1151,12 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
         cooldown.markRequestOrdered(level, request.getId());
         diagnostics.recordPendingSource(request.getId(), "tickPending:partial");
       } else {
-        pendingTracker.remove(request.getId());
-        cooldown.clearRequestCooldown(request.getId());
+        // Root-cause guard: keep tracking while child delivery is active.
+        // Clearing tracker here loses deliveryStarted/deliveryCreated and allows duplicate
+        // re-order.
+        pendingTracker.setPendingCount(request.getId(), 0);
+        cooldown.markRequestOrdered(level, request.getId());
+        diagnostics.recordPendingSource(request.getId(), "tickPending:await-child-complete");
       }
       if (Config.DEBUG_LOGGING.getAsBoolean()) {
         TheSettlerXCreate.LOGGER.info(
@@ -1064,6 +1196,18 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     lastPerfLogTime = now;
     TheSettlerXCreate.LOGGER.info(
         "[CreateShop] perf tickPending={}us", lastTickPendingNanos / 1000L);
+  }
+
+  private boolean shouldDropMissingChild(Level level, IToken<?> childToken) {
+    if (level == null || childToken == null) {
+      return false;
+    }
+    long now = level.getGameTime();
+    Long since = missingChildSince.putIfAbsent(childToken, now);
+    if (since == null) {
+      return false;
+    }
+    return now - since >= 40L;
   }
 
   private int computeOutstandingNeeded(
@@ -1180,7 +1324,9 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     }
     if (resolver != null) {
       resolver.handleDeliveryCancelled(manager, request);
+      return;
     }
+    logUnresolvedDeliveryCallback("cancelled", manager, request);
   }
 
   public static void onDeliveryComplete(IRequestManager manager, IRequest<?> request) {
@@ -1190,7 +1336,9 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     }
     if (resolver != null) {
       resolver.handleDeliveryComplete(manager, request);
+      return;
     }
+    logUnresolvedDeliveryCallback("complete", manager, request);
   }
 
   private static CreateShopRequestResolver findResolverForDelivery(
@@ -1223,6 +1371,54 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       // Ignore lookup errors.
     }
     return null;
+  }
+
+  private static void logUnresolvedDeliveryCallback(
+      String stage, IRequestManager manager, IRequest<?> request) {
+    if (!isDebugLoggingEnabled()) {
+      return;
+    }
+    IStandardRequestManager standard = unwrapStandardManager(manager);
+    IToken<?> requestToken = request == null ? null : request.getId();
+    IToken<?> parentToken = request == null ? null : request.getParent();
+    if (parentToken == null) {
+      parentToken = findParentTokenByChild(manager, requestToken);
+    }
+    String requestState = request == null ? "<null>" : String.valueOf(request.getState());
+    IToken<?> assignmentResolver = null;
+    String assignmentResolverClass = "<none>";
+    String ownerResolverClass = "<none>";
+    try {
+      if (standard != null && requestToken != null) {
+        assignmentResolver =
+            standard
+                .getRequestResolverRequestAssignmentDataStore()
+                .getAssignmentForValue(requestToken);
+        if (assignmentResolver != null) {
+          Object resolver = standard.getResolverHandler().getResolver(assignmentResolver);
+          assignmentResolverClass = resolver == null ? "<null>" : resolver.getClass().getName();
+        }
+      }
+    } catch (Exception ignored) {
+      assignmentResolverClass = "<error>";
+    }
+    try {
+      if (standard != null && request != null) {
+        Object owner = standard.getResolverHandler().getResolverForRequest(request);
+        ownerResolverClass = owner == null ? "<null>" : owner.getClass().getName();
+      }
+    } catch (Exception ignored) {
+      ownerResolverClass = "<error>";
+    }
+    TheSettlerXCreate.LOGGER.info(
+        "[CreateShop] root-cause unresolved-delivery-callback stage={} token={} parent={} state={} assignmentResolver={} assignmentResolverClass={} ownerResolverClass={}",
+        stage,
+        requestToken,
+        parentToken == null ? "<none>" : parentToken,
+        requestState,
+        assignmentResolver == null ? "<none>" : assignmentResolver,
+        assignmentResolverClass,
+        ownerResolverClass);
   }
 
   private void handleDeliveryCancelled(IRequestManager manager, IRequest<?> request) {
@@ -1775,6 +1971,17 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     }
   }
 
+  private static boolean isTerminalRequestState(RequestState state) {
+    if (state == null) {
+      return false;
+    }
+    return state == RequestState.CANCELLED
+        || state == RequestState.COMPLETED
+        || state == RequestState.FAILED
+        || state == RequestState.RECEIVED
+        || state == RequestState.RESOLVED;
+  }
+
   int getMaxChainSanitizeNodes() {
     return MAX_CHAIN_SANITIZE_NODES;
   }
@@ -2155,6 +2362,9 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     }
     parentDeliveryActiveSince.remove(parentToken);
     clearStaleRecoveryArm(parentToken);
+    parentLastKnownChildCount.remove(parentToken);
+    parentLastKnownChildren.remove(parentToken);
+    parentChildDropLastLogTick.remove(parentToken);
     if (deliveryChildActiveSince.isEmpty()) {
       return;
     }
@@ -2331,5 +2541,158 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       return "";
     }
     return stack.getHoverName().getString();
+  }
+
+  private void logDeliveryRootCauseSnapshot(
+      IStandardRequestManager manager,
+      Level level,
+      IRequest<?> parent,
+      IRequest<?> child,
+      IToken<?> childToken,
+      IToken<?> assignedResolverToken) {
+    if (!Config.DEBUG_LOGGING.getAsBoolean()
+        || manager == null
+        || level == null
+        || parent == null
+        || child == null
+        || childToken == null) {
+      return;
+    }
+    if (!(child.getRequest() instanceof Delivery delivery)) {
+      return;
+    }
+
+    long now = level.getGameTime();
+    Long last = deliveryRootCauseLastLogTick.get(childToken);
+    if (last != null && now - last < 100L) {
+      return;
+    }
+
+    String assignedResolverClass = "<none>";
+    boolean assignedResolverDelivery = false;
+    if (assignedResolverToken != null) {
+      try {
+        Object assignedResolver = manager.getResolverHandler().getResolver(assignedResolverToken);
+        assignedResolverClass = tryDescribeResolver(assignedResolver);
+        assignedResolverDelivery =
+            assignedResolverClass.contains("DeliveryRequestResolver")
+                || assignedResolverClass.contains("WarehouseRequestResolver");
+      } catch (Exception ignored) {
+        assignedResolverClass = "<missing>";
+      }
+    }
+
+    java.util.List<String> warehouseDebug = new java.util.ArrayList<>();
+    var buildingManager =
+        manager.getColony() == null ? null : manager.getColony().getServerBuildingManager();
+    if (buildingManager != null && buildingManager.getBuildings() != null) {
+      for (var entry : buildingManager.getBuildings().entrySet()) {
+        Object building = entry.getValue();
+        if (!(building
+                instanceof
+                com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse
+                warehouse)
+            || building
+                instanceof com.thesettler_x_create.minecolonies.building.BuildingCreateShop) {
+          continue;
+        }
+        var queue =
+            warehouse.getModule(
+                com.minecolonies.core.colony.buildings.modules.BuildingModules
+                    .WAREHOUSE_REQUEST_QUEUE);
+        boolean queueContains =
+            queue != null
+                && queue.getMutableRequestList() != null
+                && queue.getMutableRequestList().contains(childToken);
+        var couriers =
+            warehouse.getModule(
+                com.minecolonies.core.colony.buildings.modules.BuildingModules.WAREHOUSE_COURIERS);
+        int courierCount =
+            couriers == null || couriers.getAssignedCitizen() == null
+                ? 0
+                : couriers.getAssignedCitizen().size();
+        java.util.List<String> courierInfo = new java.util.ArrayList<>();
+        if (couriers != null && couriers.getAssignedCitizen() != null) {
+          for (var citizen : couriers.getAssignedCitizen()) {
+            if (citizen == null) {
+              continue;
+            }
+            String name = citizen.getName() == null ? "<unknown>" : citizen.getName();
+            String job =
+                citizen.getJob() == null ? "<none>" : citizen.getJob().getClass().getSimpleName();
+            Object id = null;
+            Object uuid = null;
+            try {
+              id = citizen.getClass().getMethod("getId").invoke(citizen);
+            } catch (Exception ignored) {
+              id = "<na>";
+            }
+            try {
+              uuid = citizen.getClass().getMethod("getUUID").invoke(citizen);
+            } catch (Exception ignored) {
+              uuid = "<na>";
+            }
+            courierInfo.add(
+                name
+                    + "{id="
+                    + id
+                    + ",uuid="
+                    + uuid
+                    + ",job="
+                    + job
+                    + ",deliveryman="
+                    + (citizen.getJob() instanceof com.minecolonies.core.colony.jobs.JobDeliveryman)
+                    + "}");
+          }
+        }
+        String location = "<unknown>";
+        try {
+          Object locObj = warehouse.getClass().getMethod("getLocation").invoke(warehouse);
+          location = String.valueOf(locObj);
+        } catch (Exception ignored) {
+          // Best-effort debug only.
+        }
+        warehouseDebug.add(
+            "warehouse{loc="
+                + location
+                + ",queueContains="
+                + queueContains
+                + ",couriers="
+                + courierCount
+                + ",courierInfo="
+                + courierInfo
+                + "}");
+      }
+    }
+
+    String snapshot =
+        "parent="
+            + parent.getId()
+            + " child="
+            + childToken
+            + " childState="
+            + child.getState()
+            + " assignedResolver="
+            + (assignedResolverToken == null ? "<none>" : assignedResolverToken)
+            + " assignedResolverClass="
+            + assignedResolverClass
+            + " assignedResolverDelivery="
+            + assignedResolverDelivery
+            + " deliveryFrom="
+            + (delivery.getStart() == null
+                ? "<null>"
+                : delivery.getStart().getInDimensionLocation())
+            + " deliveryTo="
+            + (delivery.getTarget() == null
+                ? "<null>"
+                : delivery.getTarget().getInDimensionLocation())
+            + " warehouses="
+            + warehouseDebug;
+
+    String previous = deliveryRootCauseSnapshots.put(childToken, snapshot);
+    if (!snapshot.equals(previous)) {
+      TheSettlerXCreate.LOGGER.info("[CreateShop] root-cause delivery snapshot {}", snapshot);
+      deliveryRootCauseLastLogTick.put(childToken, now);
+    }
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -880,33 +880,52 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
       int topupNeeded =
           Math.max(0, pendingCount - Math.max(0, reservedForRequest) - Math.max(0, rackAvailable));
       if (workerWorking && topupNeeded > 0) {
-        int networkAvailable = stockResolver.getNetworkAvailable(tile, deliverable);
-        int topupCount = Math.min(networkAvailable, topupNeeded);
-        if (topupCount > 0) {
-          String requesterName = messaging.resolveRequesterName(manager, request);
-          List<ItemStack> topupOrdered =
-              stockResolver.requestFromNetwork(tile, deliverable, topupCount, requesterName);
-          if (!topupOrdered.isEmpty()) {
-            for (ItemStack stack : topupOrdered) {
-              if (stack.isEmpty()) {
-                continue;
+        String requesterName = messaging.resolveRequesterName(manager, request);
+        int inflightRemaining =
+            pickup.getInflightRemaining(
+                deliverable.getResult(), requesterName, tile.getShopAddress());
+        if (inflightRemaining > 0) {
+          cooldown.markRequestOrdered(level, request.getId());
+          pendingTracker.setPendingCount(request.getId(), pendingCount);
+          diagnostics.recordPendingSource(request.getId(), "tickPending:wait-inflight");
+          flowStateMachine.touch(request.getId(), level.getGameTime(), "tickPending:wait-inflight");
+          if (Config.DEBUG_LOGGING.getAsBoolean()) {
+            TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] tickPending: {} network topup blocked (inflightRemaining={}, pending={}, reserved={}, rack={})",
+                requestIdLog,
+                inflightRemaining,
+                pendingCount,
+                reservedForRequest,
+                rackAvailable);
+          }
+        } else {
+          int networkAvailable = stockResolver.getNetworkAvailable(tile, deliverable);
+          int topupCount = Math.min(networkAvailable, topupNeeded);
+          if (topupCount > 0) {
+            List<ItemStack> topupOrdered =
+                stockResolver.requestFromNetwork(tile, deliverable, topupCount, requesterName);
+            if (!topupOrdered.isEmpty()) {
+              for (ItemStack stack : topupOrdered) {
+                if (stack.isEmpty()) {
+                  continue;
+                }
+                pickup.reserve(requestId, stack.copy(), stack.getCount());
               }
-              pickup.reserve(requestId, stack.copy(), stack.getCount());
-            }
-            cooldown.markRequestOrdered(level, request.getId());
-            pendingTracker.setPendingCount(request.getId(), pendingCount);
-            diagnostics.recordPendingSource(request.getId(), "tickPending:network-topup");
-            flowStateMachine.touch(
-                request.getId(), level.getGameTime(), "tickPending:network-topup");
-            messaging.sendShopChat(
-                manager, "com.thesettler_x_create.message.createshop.request_sent", topupOrdered);
-            if (Config.DEBUG_LOGGING.getAsBoolean()) {
-              TheSettlerXCreate.LOGGER.info(
-                  "[CreateShop] tickPending: {} network topup ordered={} pending={} reserved={}",
-                  requestIdLog,
-                  countStackList(topupOrdered),
-                  pendingCount,
-                  reservedForRequest);
+              cooldown.markRequestOrdered(level, request.getId());
+              pendingTracker.setPendingCount(request.getId(), pendingCount);
+              diagnostics.recordPendingSource(request.getId(), "tickPending:network-topup");
+              flowStateMachine.touch(
+                  request.getId(), level.getGameTime(), "tickPending:network-topup");
+              messaging.sendShopChat(
+                  manager, "com.thesettler_x_create.message.createshop.request_sent", topupOrdered);
+              if (Config.DEBUG_LOGGING.getAsBoolean()) {
+                TheSettlerXCreate.LOGGER.info(
+                    "[CreateShop] tickPending: {} network topup ordered={} pending={} reserved={}",
+                    requestIdLog,
+                    countStackList(topupOrdered),
+                    pendingCount,
+                    reservedForRequest);
+              }
             }
           }
         }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverDiagnostics.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverDiagnostics.java
@@ -20,8 +20,11 @@ final class CreateShopResolverDiagnostics {
     }
     var handler = manager.getRequestHandler();
     logRequestStateChange(manager, parentToken, phase);
-    IRequest<?> parent = handler.getRequest(parentToken);
-    var children = java.util.Objects.requireNonNull(parent.getChildren(), "children");
+    IRequest<?> parent = handler.getRequestOrNull(parentToken);
+    if (parent == null || parent.getChildren() == null) {
+      return;
+    }
+    var children = parent.getChildren();
     StringBuilder builder = new StringBuilder();
     builder.append("count=").append(children.size());
     for (IToken<?> child : children) {
@@ -29,7 +32,7 @@ final class CreateShopResolverDiagnostics {
         continue;
       }
       logRequestStateChange(manager, child, phase + "-child");
-      IRequest<?> childReq = handler.getRequest(child);
+      IRequest<?> childReq = handler.getRequestOrNull(child);
       String childState = childReq == null ? "<null>" : childReq.getState().toString();
       builder.append(" ").append(child).append(":").append(childState);
     }

--- a/src/main/resources/assets/thesettler_x_create/lang/de_de.json
+++ b/src/main/resources/assets/thesettler_x_create/lang/de_de.json
@@ -27,5 +27,7 @@
   "com.thesettler_x_create.interaction.createshop.lost_package.response_reorder": "Neu bestellen",
   "com.thesettler_x_create.interaction.createshop.lost_package.answer_reorder": "Ich fordere Ersatz an.",
   "com.thesettler_x_create.interaction.createshop.lost_package.response_handover": "Paket uebergeben",
-  "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover": "Ich packe es jetzt aus."
+  "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover": "Ich packe es jetzt aus.",
+  "com.thesettler_x_create.interaction.createshop.lost_package.response_cancel": "Anfrage abbrechen",
+  "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel": "Ich breche die haengende Anfrage ab."
 }

--- a/src/main/resources/assets/thesettler_x_create/lang/de_de.json
+++ b/src/main/resources/assets/thesettler_x_create/lang/de_de.json
@@ -29,5 +29,9 @@
   "com.thesettler_x_create.interaction.createshop.lost_package.response_handover": "Paket uebergeben",
   "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover": "Ich packe es jetzt aus.",
   "com.thesettler_x_create.interaction.createshop.lost_package.response_cancel": "Anfrage abbrechen",
-  "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel": "Ich breche die haengende Anfrage ab."
+  "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel": "Ich breche die haengende Anfrage ab.",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.id": "createshop_lost_package_reorder_unavailable",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.inquiry": "Neu-Bestellung fehlgeschlagen fuer %s. Nicht genug Items im Stock Network fuer %s x%s (Adresse: %s).",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.response_back": "Zurueck",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.answer_back": "Verstanden. Ich gehe zurueck zu den Missing-Package-Optionen."
 }

--- a/src/main/resources/assets/thesettler_x_create/lang/en_us.json
+++ b/src/main/resources/assets/thesettler_x_create/lang/en_us.json
@@ -67,6 +67,10 @@
   "com.thesettler_x_create.interaction.createshop.lost_package.response_handover": "Hand over package",
   "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover": "I'll unpack it now.",
   "com.thesettler_x_create.interaction.createshop.lost_package.response_cancel": "Cancel request",
-  "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel": "I'll cancel the stuck request."
+  "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel": "I'll cancel the stuck request.",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.id": "createshop_lost_package_reorder_unavailable",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.inquiry": "Re-order failed for %s. Not enough items in the stock network for %s x%s (address: %s).",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.response_back": "Back",
+  "com.thesettler_x_create.interaction.createshop.lost_package.reorder_unavailable.answer_back": "Understood. I'll return to the lost package options."
 }
 

--- a/src/main/resources/assets/thesettler_x_create/lang/en_us.json
+++ b/src/main/resources/assets/thesettler_x_create/lang/en_us.json
@@ -65,6 +65,8 @@
   "com.thesettler_x_create.interaction.createshop.lost_package.response_reorder": "Start a new order",
   "com.thesettler_x_create.interaction.createshop.lost_package.answer_reorder": "I'll request a replacement.",
   "com.thesettler_x_create.interaction.createshop.lost_package.response_handover": "Hand over package",
-  "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover": "I'll unpack it now."
+  "com.thesettler_x_create.interaction.createshop.lost_package.answer_handover": "I'll unpack it now.",
+  "com.thesettler_x_create.interaction.createshop.lost_package.response_cancel": "Cancel request",
+  "com.thesettler_x_create.interaction.createshop.lost_package.answer_cancel": "I'll cancel the stuck request."
 }
 

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingResolverGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingResolverGuardTest.java
@@ -17,5 +17,10 @@ class BuildingCreateShopHousekeepingResolverGuardTest {
     assertTrue(source.contains("resolver != null && resolver.hasActiveWork()"));
     assertTrue(
         source.contains("housekeeping blocked reason=resolver-active-work pendingUnreserved={}"));
+    assertTrue(source.contains("hasActiveLocalDeliveryChildren(colony, pickup)"));
+    assertTrue(
+        source.contains("housekeeping blocked reason=active-delivery-child pendingUnreserved={}"));
+    assertTrue(source.contains("for (var assignmentEntry : assignments.entrySet())"));
+    assertTrue(source.contains("isLocalCreateShopDeliveryParent(standard, request)"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopInteractionEpochResetGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopInteractionEpochResetGuardTest.java
@@ -1,0 +1,20 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BuildingCreateShopInteractionEpochResetGuardTest {
+  @Test
+  void resetLiveStateInvalidatesOldLostPackageInteractions() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
+
+    assertTrue(source.contains("lostPackageInteractionEpoch++;"));
+    assertTrue(source.contains("long getLostPackageInteractionEpoch()"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageCancelRequestGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageCancelRequestGuardTest.java
@@ -16,6 +16,9 @@ class BuildingCreateShopLostPackageCancelRequestGuardTest {
 
     assertTrue(source.contains("cancelLostPackageRequestAndInflight("));
     assertTrue(source.contains("cancelMatchingLostPackageRequests("));
+    assertTrue(source.contains("matchesLostPackageRequest("));
+    assertTrue(source.contains("request.getChildren()"));
+    assertTrue(source.contains("instanceof Delivery"));
     assertTrue(
         source.contains("standard.updateRequestState(request.getId(), RequestState.CANCELLED);"));
   }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageCancelRequestGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageCancelRequestGuardTest.java
@@ -15,10 +15,12 @@ class BuildingCreateShopLostPackageCancelRequestGuardTest {
                 "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
 
     assertTrue(source.contains("cancelLostPackageRequestAndInflight("));
-    assertTrue(source.contains("cancelMatchingLostPackageRequests("));
+    assertTrue(source.contains("cancelMatchingLostPackageRequests(stackKey, requesterName, address, requestedAt)"));
     assertTrue(source.contains("matchesLostPackageRequest("));
     assertTrue(source.contains("request.getChildren()"));
     assertTrue(source.contains("instanceof Delivery"));
+    assertTrue(source.contains("matchesLostPackageAddress("));
+    assertTrue(source.contains("requestedAt > 0L"));
     assertTrue(
         source.contains("standard.updateRequestState(request.getId(), RequestState.CANCELLED);"));
   }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageCancelRequestGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageCancelRequestGuardTest.java
@@ -1,0 +1,22 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BuildingCreateShopLostPackageCancelRequestGuardTest {
+  @Test
+  void cancelLostPackageCanCancelMatchingCreateShopRequests() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
+
+    assertTrue(source.contains("cancelLostPackageRequestAndInflight("));
+    assertTrue(source.contains("cancelMatchingLostPackageRequests("));
+    assertTrue(
+        source.contains("standard.updateRequestState(request.getId(), RequestState.CANCELLED);"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageReorderStatusGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageReorderStatusGuardTest.java
@@ -1,0 +1,23 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BuildingCreateShopLostPackageReorderStatusGuardTest {
+  @Test
+  void restartDetailedDistinguishesNoNetworkStock() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
+
+    assertTrue(source.contains("restartLostPackageDetailed("));
+    assertTrue(source.contains("LostPackageReorderStatus.NO_NETWORK_STOCK"));
+    assertTrue(
+        source.contains(
+            "new LostPackageReorderResult(0, LostPackageReorderStatus.NO_NETWORK_STOCK)"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageRestartInflightGateGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageRestartInflightGateGuardTest.java
@@ -14,7 +14,8 @@ class BuildingCreateShopLostPackageRestartInflightGateGuardTest {
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
 
-    assertTrue(source.contains("int trackedRemaining = pickup.getInflightRemaining("));
+    assertTrue(source.contains("pickup.getInflightRemaining("));
+    assertTrue(source.contains("requestedAt"));
     assertTrue(
         source.contains(
             "int reorderTarget = Math.min(Math.max(1, remaining), Math.max(0, trackedRemaining));"));

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageRestartPartialGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageRestartPartialGuardTest.java
@@ -15,7 +15,12 @@ class BuildingCreateShopLostPackageRestartPartialGuardTest {
                 "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
 
     assertTrue(source.contains("public int restartLostPackage("));
-    assertTrue(source.contains("return consumed;"));
+    assertTrue(
+        source.contains(
+            "return restartLostPackageDetailed(stackKey, remaining, requesterName, address).consumed();"));
+    assertTrue(
+        source.contains(
+            "new LostPackageReorderResult(consumed, LostPackageReorderStatus.SUCCESS);"));
     assertTrue(source.contains("lost-package restart requester={}"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageRestartPartialGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopLostPackageRestartPartialGuardTest.java
@@ -17,7 +17,7 @@ class BuildingCreateShopLostPackageRestartPartialGuardTest {
     assertTrue(source.contains("public int restartLostPackage("));
     assertTrue(
         source.contains(
-            "return restartLostPackageDetailed(stackKey, remaining, requesterName, address).consumed();"));
+            "restartLostPackageDetailed(stackKey, remaining, requesterName, address, requestedAt)"));
     assertTrue(
         source.contains(
             "new LostPackageReorderResult(consumed, LostPackageReorderStatus.SUCCESS);"));

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopInflightTrackerGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopInflightTrackerGuardTest.java
@@ -1,0 +1,27 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopInflightTrackerGuardTest {
+  @Test
+  void skipsLostPackagePromptWhileLocalDeliveryIsActive() throws Exception {
+    String trackerSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopInflightTracker.java"));
+    String buildingSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
+
+    assertTrue(trackerSource.contains("hasActiveLocalDeliveryChildrenForInflight(colony)"));
+    assertTrue(
+        trackerSource.contains("lost-package interaction skipped: local delivery still active"));
+    assertTrue(
+        buildingSource.contains("hasActiveLocalDeliveryChildrenForInflight(IColony colony)"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionCancelOptionGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionCancelOptionGuardTest.java
@@ -1,0 +1,22 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopLostPackageInteractionCancelOptionGuardTest {
+  @Test
+  void interactionExposesCancelOptionAndRoutesResponse() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java"));
+
+    assertTrue(source.contains("lost_package.response_cancel"));
+    assertTrue(source.contains("lost_package.answer_cancel"));
+    assertTrue(source.contains("response == 2"));
+    assertTrue(source.contains("cancelLostPackageRequestAndInflight("));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionImmediateLockGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionImmediateLockGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopLostPackageInteractionImmediateLockGuardTest {
+  @Test
+  void responseHandlerLocksInteractionBeforeProcessing() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java"));
+
+    assertTrue(source.contains("active = false;"));
+    assertTrue(source.contains("Re-arm the dialog when nothing was consumed"));
+    assertTrue(source.contains("active = true;"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionReorderUnavailableGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionReorderUnavailableGuardTest.java
@@ -1,0 +1,20 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopLostPackageInteractionReorderUnavailableGuardTest {
+  @Test
+  void reorderUnavailableRoutesToDedicatedInteraction() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java"));
+
+    assertTrue(source.contains("BuildingCreateShop.LostPackageReorderStatus.NO_NETWORK_STOCK"));
+    assertTrue(source.contains("new ShopLostPackageReorderUnavailableInteraction("));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionSelfRetentionGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionSelfRetentionGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopLostPackageInteractionSelfRetentionGuardTest {
+  @Test
+  void currentInteractionIsNotRemovedFromQueueDuringTupleCleanup() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java"));
+
+    assertTrue(source.contains("if (other == this) {"));
+    assertTrue(source.contains("return false;"));
+    assertTrue(source.contains("no-op response can re-arm"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionStaleGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteractionStaleGuardTest.java
@@ -1,0 +1,22 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopLostPackageInteractionStaleGuardTest {
+  @Test
+  void interactionRejectsStaleResponsesAfterResetOrTupleResolution() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageInteraction.java"));
+
+    assertTrue(source.contains("if (!isStillTracked(shop))"));
+    assertTrue(source.contains("interactionEpoch != shop.getLostPackageInteractionEpoch()"));
+    assertTrue(
+        source.contains("getInflightRemaining(stackKey, requesterName, address, requestedAt)"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteractionGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteractionGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopLostPackageReorderUnavailableInteractionGuardTest {
+  @Test
+  void interactionUsesSingleBackActionAndReturnsToLostPackageDialog() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopLostPackageReorderUnavailableInteraction.java"));
+
+    assertTrue(source.contains("lost_package.reorder_unavailable.response_back"));
+    assertTrue(source.contains("lost_package.reorder_unavailable.answer_back"));
+    assertTrue(source.contains("new ShopLostPackageInteraction("));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommandsGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommandsGuardTest.java
@@ -20,5 +20,7 @@ class CreateShopMaintenanceCommandsGuardTest {
     assertTrue(mainSource.contains("CreateShopMaintenanceCommands.register"));
     assertTrue(commandSource.contains("thesettlerxcreate"));
     assertTrue(commandSource.contains("prepare_uninstall"));
+    assertTrue(commandSource.contains("run_live_test"));
+    assertTrue(commandSource.contains("reset_live_state"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommandsGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommandsGuardTest.java
@@ -22,5 +22,14 @@ class CreateShopMaintenanceCommandsGuardTest {
     assertTrue(commandSource.contains("prepare_uninstall"));
     assertTrue(commandSource.contains("run_live_test"));
     assertTrue(commandSource.contains("reset_live_state"));
+    assertTrue(commandSource.contains("force_warehouse_queue"));
+    assertTrue(commandSource.contains("clearWarehouseQueues("));
+    assertTrue(commandSource.contains("cancelCreateShopOwnedRequestsGraphAware("));
+    assertTrue(commandSource.contains("cancelRequestGraphPostOrder("));
+    assertTrue(commandSource.contains("cancelSingleRequest("));
+    assertTrue(commandSource.contains("countShopsWithActiveLocalDeliveries("));
+    assertTrue(commandSource.contains("reconcileAssignmentsAndKickCouriers("));
+    assertTrue(commandSource.contains("cancelActiveLocalDeliveries("));
+    assertTrue(commandSource.contains("drainRounds"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryTrackerStartedGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryTrackerStartedGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopPendingDeliveryTrackerStartedGuardTest {
+  @Test
+  void trackerPersistsDeliveryStartedSignal() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopPendingDeliveryTracker.java"));
+
+    assertTrue(source.contains("state.setDeliveryStarted(true)"));
+    assertTrue(source.contains("boolean hasDeliveryStarted(IToken<?> token)"));
+    assertTrue(source.contains("!state.isDeliveryStarted()"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverInflightTopupGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverInflightTopupGuardTest.java
@@ -1,0 +1,23 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopRequestResolverInflightTopupGuardTest {
+  @Test
+  void tickPendingBlocksNetworkTopupWhenInflightForTupleIsStillOpen() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java"));
+
+    assertTrue(source.contains("pickup.getInflightRemaining("));
+    assertTrue(source.contains("deliverable.getResult()"));
+    assertTrue(source.contains("tile.getShopAddress()"));
+    assertTrue(source.contains("tickPending:wait-inflight"));
+    assertTrue(source.contains("network topup blocked (inflightRemaining="));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverStartedOrderGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverStartedOrderGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopRequestResolverStartedOrderGuardTest {
+  @Test
+  void blocksAutoReorderAfterFirstDeliveryStart() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java"));
+
+    assertTrue(source.contains("pendingTracker.hasDeliveryStarted(request.getId())"));
+    assertTrue(source.contains("attemptResolve:block-auto-reorder-started"));
+    assertTrue(source.contains("tickPending:block-auto-reorder-started"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverTerminalGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverTerminalGuardTest.java
@@ -1,0 +1,22 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopRequestResolverTerminalGuardTest {
+  @Test
+  void tickPendingSkipsTerminalParentRequests() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java"));
+
+    assertTrue(source.contains("if (isTerminalRequestState(request.getState()))"));
+    assertTrue(source.contains("skip:terminal-state"));
+    assertTrue(
+        source.contains("private static boolean isTerminalRequestState(RequestState state)"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverDiagnosticsGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverDiagnosticsGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopResolverDiagnosticsGuardTest {
+  @Test
+  void parentChildrenLoggingUsesFailOpenRequestLookup() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverDiagnostics.java"));
+
+    assertTrue(source.contains("handler.getRequestOrNull(parentToken)"));
+    assertTrue(source.contains("handler.getRequestOrNull(child)"));
+    assertTrue(source.contains("parent == null || parent.getChildren() == null"));
+  }
+}


### PR DESCRIPTION
This PR hardens CreateShop request lifecycle handling around inflight/lost-package scenarios and delivery transitions, with focus on root-cause fixes over symptom-only guards.

### What Changed
1. Lost-package recovery flow
- Added/extended explicit actions for overdue inflight handling:
  - `handover package`
  - `re-order from network`
  - `cancel request`
- Improved tuple-aware handling (`item + requester + address + requestedAt`) to avoid mismatched recovery actions.
- Added reorder-unavailable interaction path (no silent close on missing network stock).

2. Delivery lifecycle stability
- Strengthened pending/started/terminal request transitions in resolver path.
- Improved delivery child creation/diagnostics flow and guard behavior to reduce resolver drift.
- Hardened local delivery tracking and cleanup behavior for stuck/legacy queue states.

3. Live reset / maintenance behavior
- Improved live reset command behavior for stale runtime/request graph cleanup.
- Added/extended maintenance guards so test cleanup produces a predictable clean state.

4. Interaction behavior
- Improved lost-package interaction handling so response processing is robust and less prone to duplicate/stale dialog behavior.
- Reduced incorrect cross-impact between unrelated lost-package cases by tighter matching logic.

5. Diagnostics and observability
- Added/extended guard diagnostics for pending tracker, resolver terminal handling, and delivery diagnostics.
- Expanded targeted logging for root-cause analysis in live runs.

### Why
We repeatedly hit drift between:
- inflight tracking
- parent/child request lifecycle
- delivery queue/assignment visibility

This PR consolidates and hardens those boundaries so overdue/lost flows remain deterministic and recoverable without hidden reorders or stuck transitional states.

### Risk / Impact
- Moderate: touches core CreateShop resolver + lost-package interaction paths.
- Mitigated by:
  - guard tests
  - explicit tuple matching
  - stricter transition guards and cleanup behavior