### PR TITLE
Add Create Shop inflight task visibility and native pickup routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out
 *.iws
 *.iml
 .idea
+.vscode/
 
 # gradle
 build

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ out
 # gradle
 build
 .gradle
+.gradle-user-home/
 
 # other
 eclipse
@@ -36,3 +37,4 @@ Backups/*.zip
 libs/
 FEATURE_STATUS.md
 PROJECT_TODO_LOCAL.md
+AGENTS.md

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -385,6 +385,8 @@ Known focus area:
   - one-shot aggregate command:
     `/thesettlerxcreate auto_test_harness_full_all`
   This allows repeatable command-driven scenario runs without manual UI interaction for each step.
+- Create Shop task-tab now includes local inflight parent requests in addition to the warehouse
+  queue list, so active Create Shop inflight work is visible directly in the existing task-tab UI.
 - Lost-package harness support added in core runtime:
   - `CreateShopBlockEntity` debug inflight tuple inject + oldest tuple peek helpers
   - `BuildingCreateShop` debug wrappers for reorder and simulated handover consumption.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -354,6 +354,9 @@ Known focus area:
   so it does not drop into idle while pending resolvable requests or rack cleanup work remain.
 - Incoming rack housekeeping now runs in small timed batches, moving only unreserved rack items into
   hut inventory and leaving reserved quantities in place for MineColonies delivery creation.
+- After successful rack->hut housekeeping moves, Create Shop now triggers MineColonies-native
+  `createPickupRequest(...)` (respecting building pickup priority), so courier transport to
+  warehouse is requested from hut inventory only, not directly from racks.
 - Incoming rack housekeeping is now resolver-work gated: rack->hut transfers pause while the local
   Create Shop resolver still has active request work, reducing reservation-race drift where fresh
   incoming request items could be moved before delivery linkage settles.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -387,6 +387,8 @@ Known focus area:
   This allows repeatable command-driven scenario runs without manual UI interaction for each step.
 - Create Shop task-tab now includes local inflight parent requests in addition to the warehouse
   queue list, so active Create Shop inflight work is visible directly in the existing task-tab UI.
+- Project version for this integration line is now `0.2.0` (`gradle.properties` `mod_version`),
+  covering native rack->hut->pickup routing and task-tab inflight visibility updates.
 - Lost-package harness support added in core runtime:
   - `CreateShopBlockEntity` debug inflight tuple inject + oldest tuple peek helpers
   - `BuildingCreateShop` debug wrappers for reorder and simulated handover consumption.

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -334,6 +334,10 @@ Current behavior:
   when local counters diverge from request graph state.
 - Rehydrate now expands from assignment tokens to active runtime child/parent lifecycle tokens and
   prunes orphan child entries, improving reload recovery for persisted/inflight request graphs.
+- Delivery-complete callbacks now close the original parent request when the Create Shop-created
+  delivery child is terminal and no pending remainder or active children remain. Terminal child
+  links are detached first, then the parent is marked `RESOLVED`, preventing successfully delivered
+  Postbox orders from remaining open when MineColonies finalizes only the child delivery request.
 
 Known focus area:
 - Live-world validation for long-running colonies under resolver-token drift and worker status churn.
@@ -387,6 +391,12 @@ Known focus area:
   This allows repeatable command-driven scenario runs without manual UI interaction for each step.
 - Create Shop task-tab now includes local inflight parent requests in addition to the warehouse
   queue list, so active Create Shop inflight work is visible directly in the existing task-tab UI.
+- Create Shop delivery children now use a serializable requester wrapper that delegates to the
+  native warehouse requester while exposing the Create Shop source location and routing completion/
+  cancellation callbacks back to the local resolver.
+- Delivery-child diagnostics and reservation handling have expanded guard coverage for requester
+  binding, queue-only dispatch, notify accounting, local reservation holds, and completion-ledger
+  evidence during live delivery recovery.
 - Project version for this integration line is now `0.2.0` (`gradle.properties` `mod_version`),
   covering native rack->hut->pickup routing and task-tab inflight visibility updates.
 - Lost-package harness support added in core runtime:

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -709,3 +709,8 @@ Implementation notes:
   authored in this project scope: maintenance commands now include repeatable live scenario
   automation (`auto_test_harness` + `auto_test_harness_full_all`) including lost-package inject,
   reorder, handover simulation, and cancel flows for command-driven in-game validation.
+- Shop request-pickup integration on branch `feature/shop-request-pickup` (2026-03-30) is authored
+  in this project scope: after Create Shop housekeeping moves unreserved items from rack to hut
+  inventory, the building now triggers MineColonies-native `createPickupRequest(...)` with building
+  pickup priority so courier pickup remains hut-handler based (rack -> hut -> warehouse) without
+  custom courier dispatch or parallel delivery structures.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -714,3 +714,8 @@ Implementation notes:
   inventory, the building now triggers MineColonies-native `createPickupRequest(...)` with building
   pickup priority so courier pickup remains hut-handler based (rack -> hut -> warehouse) without
   custom courier dispatch or parallel delivery structures.
+- Task-tab inflight visibility on branch `feature/task-tab-inflight-visibility` (2026-03-30) is
+  authored in this project scope: Create Shop replaces the default warehouse request-queue module
+  view wiring with a custom task module/view pair that serializes additional local inflight parent
+  request tokens (owned by the local Create Shop resolver) and merges them with queue tasks in the
+  existing MineColonies task-tab UI without introducing parallel request storage.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -719,3 +719,6 @@ Implementation notes:
   view wiring with a custom task module/view pair that serializes additional local inflight parent
   request tokens (owned by the local Create Shop resolver) and merges them with queue tasks in the
   existing MineColonies task-tab UI without introducing parallel request storage.
+- Versioning update on branch `feature/task-tab-inflight-visibility` (2026-03-30) is authored in
+  this project scope: build metadata in `gradle.properties` was bumped from `0.1.0` to `0.2.0` as
+  part of the task-tab inflight visibility + native pickup integration release line.

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -719,6 +719,21 @@ Implementation notes:
   view wiring with a custom task module/view pair that serializes additional local inflight parent
   request tokens (owned by the local Create Shop resolver) and merges them with queue tasks in the
   existing MineColonies task-tab UI without introducing parallel request storage.
+- Create Shop delivery requester binding on branch `feature/task-tab-inflight-visibility`
+  (2026-03-30) is authored in this project scope: Create Shop-sourced delivery children use a
+  serializable requester wrapper that keeps the native warehouse requester delegate while exposing
+  the Create Shop source location and routing delivery complete/cancel callbacks back through the
+  local resolver.
+- Delivery reservation/diagnostic hardening on branch `feature/task-tab-inflight-visibility`
+  (2026-03-30) is authored in this project scope: local delivery completion keeps reservation
+  consumption tied to terminal child delivery evidence, expands ledger/root-cause diagnostics, and
+  adds guard coverage for queue-only dispatch, requester binding, notify counts, and reservation
+  holds.
 - Versioning update on branch `feature/task-tab-inflight-visibility` (2026-03-30) is authored in
   this project scope: build metadata in `gradle.properties` was bumped from `0.1.0` to `0.2.0` as
   part of the task-tab inflight visibility + native pickup integration release line.
+- Postbox parent completion hardening (2026-04-25) is authored in this project scope: when a
+  Create Shop-created delivery child completes and no pending remainder or active child request
+  remains, `CreateShopDeliveryCompletionService` now detaches terminal delivery children and marks
+  the original parent request `RESOLVED`, preserving the native request graph while preventing
+  delivered Postbox requests from staying open when MineColonies only finalizes the delivery child.

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ mod_name=TheSettler_x_Create
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=0.1.0
+mod_version=0.2.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/thesettler_x_create/TheSettlerXCreate.java
+++ b/src/main/java/com/thesettler_x_create/TheSettlerXCreate.java
@@ -17,6 +17,7 @@ import com.thesettler_x_create.minecolonies.command.CreateShopMaintenanceCommand
 import com.thesettler_x_create.minecolonies.debug.NativeRequestFlowDiagnostics;
 import com.thesettler_x_create.minecolonies.registry.ModMinecoloniesBuildings;
 import com.thesettler_x_create.minecolonies.registry.ModMinecoloniesJobs;
+import com.thesettler_x_create.minecolonies.requestsystem.requesters.CreateShopDeliveryRequesterFactory;
 import com.thesettler_x_create.minecolonies.requestsystem.requesters.SafeRequesterFactory;
 import com.thesettler_x_create.minecolonies.requestsystem.resolver.CreateShopRequestResolverFactory;
 import com.thesettler_x_create.network.ModNetwork;
@@ -83,6 +84,12 @@ public class TheSettlerXCreate {
           try {
             // Legacy compatibility: keep requester factory 3001 deserializable for old saves.
             StandardFactoryController.getInstance().registerNewFactory(new SafeRequesterFactory());
+          } catch (IllegalArgumentException ignored) {
+            // Ignore duplicate factory registration across reloads.
+          }
+          try {
+            StandardFactoryController.getInstance()
+                .registerNewFactory(new CreateShopDeliveryRequesterFactory());
           } catch (IllegalArgumentException ignored) {
             // Ignore duplicate factory registration across reloads.
           }

--- a/src/main/java/com/thesettler_x_create/blockentity/CreateShopBlockEntity.java
+++ b/src/main/java/com/thesettler_x_create/blockentity/CreateShopBlockEntity.java
@@ -897,7 +897,6 @@ public class CreateShopBlockEntity extends BlockEntity {
             ItemStack.parse(registries, entry.getCompound("stack")).orElse(ItemStack.EMPTY);
         int remaining = entry.getInt("remaining");
         long requestedAt = entry.getLong("requestedAt");
-        boolean notified = entry.getBoolean("notified");
         String requester = entry.getString("requester");
         String address = entry.getString("address");
         if (!stack.isEmpty() && remaining > 0) {
@@ -977,7 +976,6 @@ public class CreateShopBlockEntity extends BlockEntity {
     }
   }
 
-  @SuppressWarnings("unused")
   public IItemHandler getItemHandler(@Nullable Direction side) {
     return itemHandler;
   }

--- a/src/main/java/com/thesettler_x_create/create/CreateNetworkFacade.java
+++ b/src/main/java/com/thesettler_x_create/create/CreateNetworkFacade.java
@@ -101,7 +101,8 @@ public class CreateNetworkFacade implements ICreateNetworkFacade {
     if (stack == null || stack.isEmpty() || amount <= 0) {
       return ItemStack.EMPTY;
     }
-    // TODO: Replace with Create API call that removes items from the network.
+    // This facade only previews extractable stock; actual movement is requested via
+    // LogisticsManager.broadcastPackageRequest in requestStacks.
     int available = getAvailable(stack);
     int toExtract = Math.min(amount, available);
     if (toExtract <= 0) {

--- a/src/main/java/com/thesettler_x_create/item/StockLinkLinkerItem.java
+++ b/src/main/java/com/thesettler_x_create/item/StockLinkLinkerItem.java
@@ -21,7 +21,6 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.CustomData;

--- a/src/main/java/com/thesettler_x_create/menu/CreateShopMenu.java
+++ b/src/main/java/com/thesettler_x_create/menu/CreateShopMenu.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.Level;
 
 public class CreateShopMenu extends AbstractContainerMenu {
   private final TileEntityCreateShop shop;
-  private final Level level;
   private final BlockPos pos;
 
   public CreateShopMenu(int id, Inventory playerInventory, RegistryFriendlyByteBuf buf) {
@@ -25,7 +24,6 @@ public class CreateShopMenu extends AbstractContainerMenu {
 
   private CreateShopMenu(int id, Inventory playerInventory, Level level, BlockPos pos) {
     super(ModMenus.CREATE_SHOP.get(), id);
-    this.level = level;
     this.pos = pos;
     this.shop = level.getBlockEntity(pos) instanceof TileEntityCreateShop te ? te : null;
   }

--- a/src/main/java/com/thesettler_x_create/minecolonies/ai/EntityAIWorkCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/ai/EntityAIWorkCreateShop.java
@@ -12,6 +12,7 @@ import com.thesettler_x_create.minecolonies.job.JobCreateShop;
 
 public class EntityAIWorkCreateShop
     extends AbstractEntityAIInteract<JobCreateShop, BuildingCreateShop> {
+  @SuppressWarnings("unchecked")
   public EntityAIWorkCreateShop(JobCreateShop job) {
     super(job);
     registerTargets(

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -988,6 +988,22 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     if (moved > 0 || cachedHasIncomingRackWork) {
       lastHousekeepingTransferTick = now;
     }
+    if (moved > 0) {
+      int pickupPriority = getPickUpPriority();
+      if (pickupPriority > 0) {
+        boolean pickupRequested = createPickupRequest(pickupPriority);
+        if (isDebugRequests()) {
+          com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+              "[CreateShop] housekeeping pickup request priority={} created={} moved={}",
+              pickupPriority,
+              pickupRequested,
+              moved);
+        }
+      } else if (isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] housekeeping pickup request skipped (priority disabled) moved={}", moved);
+      }
+    }
     if (moved > 0 && isDebugRequests()) {
       com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
           "[CreateShop] housekeeping moved unreserved rack stacks to hut count={} budget={} elapsed={}t",

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -6,7 +6,9 @@ import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.AbstractDeliverymanRequestable;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Pickup;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.tileentities.AbstractTileEntityWareHouse;
@@ -16,6 +18,7 @@ import com.minecolonies.core.colony.buildings.AbstractBuilding;
 import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.CourierAssignmentModule;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
+import com.minecolonies.core.colony.requestsystem.resolvers.PickupRequestResolver;
 import com.minecolonies.core.tileentities.TileEntityRack;
 import com.simibubi.create.content.logistics.BigItemStack;
 import com.thesettler_x_create.Config;
@@ -27,6 +30,7 @@ import com.thesettler_x_create.create.CreateNetworkFacade;
 import com.thesettler_x_create.minecolonies.requestsystem.resolver.CreateShopRequestResolver;
 import com.thesettler_x_create.minecolonies.tileentity.TileEntityCreateShop;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1029,7 +1033,144 @@ public class BuildingCreateShop extends AbstractBuilding {
    * location.
    */
   private boolean createNativeHutPickupRequest(int pickupPriority) {
-    return createPickupRequest(pickupPriority);
+    int effectivePriority =
+        Math.max(pickupPriority, AbstractDeliverymanRequestable.getPlayerActionPriority(false));
+    return createPickupRequest(effectivePriority);
+  }
+
+  @Override
+  public boolean createPickupRequest(int pickupPriority) {
+    if (!(getColony() != null
+        && getColony().getRequestManager() instanceof IStandardRequestManager standard)) {
+      return super.createPickupRequest(pickupPriority);
+    }
+
+    boolean activePickupRequest = false;
+    java.util.Collection<IToken<?>> openPickupRequests =
+        getOpenRequestsByRequestableType().get(TypeConstants.PICKUP);
+    if (openPickupRequests != null && !openPickupRequests.isEmpty()) {
+      for (IToken<?> token : List.copyOf(openPickupRequests)) {
+        if (token == null) {
+          continue;
+        }
+
+        IRequest<?> request = standard.getRequestForToken(token);
+        if (request == null) {
+          pruneStalePickupRequestToken(token, "missing-request");
+          continue;
+        }
+        if (!(request.getRequest() instanceof Pickup)) {
+          pruneStalePickupRequestToken(token, "unexpected-request-type");
+          continue;
+        }
+
+        RequestState state = request.getState();
+        if (isTerminalRequestState(state)) {
+          if (state == RequestState.CANCELLED) {
+            super.onRequestedRequestCancelled(standard, request);
+          } else {
+            super.onRequestedRequestComplete(standard, request);
+          }
+          if (isDebugRequests()) {
+            com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+                "[CreateShop] pickup request cleanup token={} state={} reason=terminal-open-token",
+                token,
+                state);
+          }
+          continue;
+        }
+
+        activePickupRequest = true;
+        repairOpenPickupRequest(standard, token, request, state);
+      }
+    }
+
+    if (activePickupRequest) {
+      return false;
+    }
+    return super.createPickupRequest(pickupPriority);
+  }
+
+  private void repairOpenPickupRequest(
+      IStandardRequestManager manager, IToken<?> token, IRequest<?> request, RequestState state) {
+    IRequestResolver<?> resolver = null;
+    try {
+      resolver = manager.getResolverForRequest(token);
+    } catch (Exception ignored) {
+      // Reassignment path below will repair missing resolver ownership.
+    }
+
+    boolean needsAssignmentKick = state == RequestState.CREATED || state == RequestState.ASSIGNED;
+    boolean invalidResolver = resolver != null && !(resolver instanceof PickupRequestResolver);
+    boolean missingResolver = resolver == null;
+
+    if (!needsAssignmentKick && !invalidResolver && !missingResolver) {
+      return;
+    }
+
+    try {
+      if (state == RequestState.IN_PROGRESS || invalidResolver || missingResolver) {
+        manager.reassignRequest(token, Collections.emptyList());
+      } else {
+        manager.assignRequest(token);
+      }
+      if (isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] pickup request repair token={} state={} resolver={} action={}",
+            token,
+            state,
+            resolver == null ? "<null>" : resolver.getClass().getSimpleName(),
+            state == RequestState.IN_PROGRESS || invalidResolver || missingResolver
+                ? "reassign"
+                : "assign");
+      }
+    } catch (Exception ex) {
+      if (isDebugRequests()) {
+        com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] pickup request repair failed token={} state={} resolver={} error={}",
+            token,
+            state,
+            resolver == null ? "<null>" : resolver.getClass().getSimpleName(),
+            ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+      }
+    }
+  }
+
+  private void pruneStalePickupRequestToken(IToken<?> token, String reason) {
+    if (token == null) {
+      return;
+    }
+    java.util.Collection<IToken<?>> openPickupRequests =
+        getOpenRequestsByRequestableType().get(TypeConstants.PICKUP);
+    if (openPickupRequests != null) {
+      openPickupRequests.remove(token);
+      if (openPickupRequests.isEmpty()) {
+        getOpenRequestsByRequestableType().remove(TypeConstants.PICKUP);
+      }
+    }
+    java.util.Collection<IToken<?>> buildingRequests = getOpenRequestsByCitizen().get(-1);
+    if (buildingRequests != null) {
+      buildingRequests.remove(token);
+      if (buildingRequests.isEmpty()) {
+        getOpenRequestsByCitizen().remove(-1);
+      }
+    }
+    markDirty();
+    if (isDebugRequests()) {
+      com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
+          "[CreateShop] pickup request cleanup token={} reason={}", token, reason);
+    }
+  }
+
+  private static boolean isTerminalRequestState(RequestState state) {
+    if (state == null) {
+      return false;
+    }
+    return state == RequestState.CANCELLED
+        || state == RequestState.COMPLETED
+        || state == RequestState.FAILED
+        || state == RequestState.RECEIVED
+        || state == RequestState.RESOLVED;
   }
 
   private boolean hasActiveLocalDeliveryChildren(IColony colony, CreateShopBlockEntity pickup) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.minecolonies.api.blocks.AbstractBlockMinecoloniesRack;
 import com.minecolonies.api.colony.ICitizenData;
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
@@ -51,7 +50,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.Nullable;
 
 /** Create Shop building integration with MineColonies request system and Create network. */
-public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
+public class BuildingCreateShop extends AbstractBuilding {
   public static final String SCHEMATIC_NAME = "createshop";
   private static final long HOUSEKEEPING_TRANSFER_INTERVAL = 20L * 3L;
   private static final long HOUSEKEEPING_DEBUG_COOLDOWN = 20L * 5L;
@@ -125,7 +124,6 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return 2;
   }
 
-  @Override
   public boolean canAccessWareHouse(ICitizenData citizen) {
     boolean result =
         citizen != null
@@ -233,7 +231,6 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     return isBuilt() && getBuildingLevel() >= Config.PERMA_MIN_BUILDING_LEVEL.getAsInt();
   }
 
-  @Override
   public boolean hasContainerPosition(BlockPos pos) {
     return containerList.contains(pos) || getLocation().getInDimensionLocation().equals(pos);
   }
@@ -354,7 +351,10 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
   @Override
   public void onDestroyed() {
     super.onDestroyed();
-    getColony().getServerBuildingManager().removeWareHouse(this);
+    var manager = getColony() == null ? null : getColony().getServerBuildingManager();
+    if (manager != null && manager.getWareHouses() != null) {
+      manager.getWareHouses().remove(this);
+    }
     warehouseRegistered = false;
   }
 
@@ -381,7 +381,6 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
     super.registerBlockPosition(block, pos, world);
   }
 
-  @Override
   public void upgradeContainers(Level level) {
     // No storage upgrades for the Create Shop yet.
   }

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -984,24 +984,28 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
             (int) Math.max(1L, elapsed / HOUSEKEEPING_TRANSFER_INTERVAL));
     int transferBudget = Math.min(HOUSEKEEPING_MAX_CATCHUP_STACKS, dueStacks);
     int moved = tile.moveUnreservedRackStacksToHut(pickup, transferBudget);
+    boolean hutHasItems = tile.hasHutInventoryItems();
     cachedHasIncomingRackWork = tile.hasUnreservedRackItems(pickup);
-    if (moved > 0 || cachedHasIncomingRackWork) {
+    if (moved > 0 || cachedHasIncomingRackWork || hutHasItems) {
       lastHousekeepingTransferTick = now;
     }
-    if (moved > 0) {
+    if (moved > 0 || hutHasItems) {
       int pickupPriority = getPickUpPriority();
       if (pickupPriority > 0) {
-        boolean pickupRequested = createPickupRequest(pickupPriority);
+        boolean pickupRequested = createNativeHutPickupRequest(pickupPriority);
         if (isDebugRequests()) {
           com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
-              "[CreateShop] housekeeping pickup request priority={} created={} moved={}",
+              "[CreateShop] housekeeping pickup request priority={} created={} moved={} hutHasItems={}",
               pickupPriority,
               pickupRequested,
-              moved);
+              moved,
+              hutHasItems);
         }
       } else if (isDebugRequests()) {
         com.thesettler_x_create.TheSettlerXCreate.LOGGER.info(
-            "[CreateShop] housekeeping pickup request skipped (priority disabled) moved={}", moved);
+            "[CreateShop] housekeeping pickup request skipped (priority disabled) moved={} hutHasItems={}",
+            moved,
+            hutHasItems);
       }
     }
     if (moved > 0 && isDebugRequests()) {
@@ -1017,6 +1021,16 @@ public class BuildingCreateShop extends AbstractBuilding implements IWareHouse {
           transferBudget,
           elapsed);
     }
+  }
+
+  /**
+   * Requests MineColonies' native building pickup flow for items staged in the hut.
+   *
+   * <p>The pickup requestable stores priority only; the source is the building requester's hut
+   * location.
+   */
+  private boolean createNativeHutPickupRequest(int pickupPriority) {
+    return createPickupRequest(pickupPriority);
   }
 
   private boolean hasActiveLocalDeliveryChildren(IColony colony, CreateShopBlockEntity pickup) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java
@@ -1054,7 +1054,13 @@ public class BuildingCreateShop extends AbstractBuilding {
           continue;
         }
 
-        IRequest<?> request = standard.getRequestForToken(token);
+        IRequest<?> request;
+        try {
+          request = standard.getRequestForToken(token);
+        } catch (Exception ignored) {
+          pruneStalePickupRequestToken(token, "lookup-failed");
+          continue;
+        }
         if (request == null) {
           pruneStalePickupRequestToken(token, "missing-request");
           continue;

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopBeltBlueprints.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopBeltBlueprints.java
@@ -576,7 +576,7 @@ final class ShopBeltBlueprints {
       }
       BlockPos rotated = rotatePos(local, transform.rotation);
       BlockPos worldPos = rotated.offset(transform.translation);
-      BlockState placed = state.rotate(transform.rotation);
+      BlockState placed = state.rotate(level, worldPos, transform.rotation);
       level.setBlockAndUpdate(worldPos, placed);
       applyTileEntityData(level, worldPos, info);
       if (min == null) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopResolverFactory.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopResolverFactory.java
@@ -24,8 +24,6 @@ final class ShopResolverFactory {
       ImmutableCollection<IRequestResolver<?>> baseResolvers) {
     ImmutableList.Builder<IRequestResolver<?>> builder = ImmutableList.builder();
     CreateShopRequestResolver existingShopResolver = null;
-    DeliveryRequestResolver existingDeliveryResolver = null;
-    PickupRequestResolver existingPickupResolver = null;
 
     for (IRequestResolver<?> resolver : baseResolvers) {
       if (resolver
@@ -35,12 +33,16 @@ final class ShopResolverFactory {
         // CreateShop is not a BuildingWareHouse; avoid MineColonies' warehouse resolver cast crash.
         continue;
       }
+      if (resolver instanceof DeliveryRequestResolver) {
+        // Deliverymen resolvers belong to real warehouses with courier modules.
+        continue;
+      }
       if (resolver instanceof CreateShopRequestResolver csr) {
         existingShopResolver = csr;
-      } else if (resolver instanceof DeliveryRequestResolver dr) {
-        existingDeliveryResolver = dr;
-      } else if (resolver instanceof PickupRequestResolver pr) {
-        existingPickupResolver = pr;
+      } else if (resolver instanceof PickupRequestResolver) {
+        // PickupRequestResolver also depends on warehouse couriers, so the Create Shop must not
+        // keep a local one. Real MineColonies warehouses resolve shop pickup requests natively.
+        continue;
       }
       builder.add(resolver);
     }
@@ -49,14 +51,6 @@ final class ShopResolverFactory {
     IFactoryController factory = shop.getColony().getRequestManager().getFactoryController();
 
     CreateShopRequestResolver shopResolver = existingShopResolver;
-    IToken<?> deliveryResolverToken =
-        existingDeliveryResolver != null
-            ? existingDeliveryResolver.getId()
-            : shop.getDeliveryResolverToken();
-    IToken<?> pickupResolverToken =
-        existingPickupResolver != null
-            ? existingPickupResolver.getId()
-            : shop.getPickupResolverToken();
 
     if (shopResolver == null) {
       IToken<?> token = factory.getNewInstance(TypeConstants.ITOKEN);
@@ -66,20 +60,7 @@ final class ShopResolverFactory {
       builder.add(shopResolver);
     }
 
-    if (existingDeliveryResolver == null && deliveryResolverToken == null) {
-      deliveryResolverToken = factory.getNewInstance(TypeConstants.ITOKEN);
-    }
-    if (existingPickupResolver == null && pickupResolverToken == null) {
-      pickupResolverToken = factory.getNewInstance(TypeConstants.ITOKEN);
-    }
-    if (existingDeliveryResolver == null) {
-      builder.add(new DeliveryRequestResolver(location, deliveryResolverToken));
-    }
-    if (existingPickupResolver == null) {
-      builder.add(new PickupRequestResolver(location, pickupResolverToken));
-    }
-
-    shop.setResolverState(shopResolver, deliveryResolverToken, pickupResolverToken);
+    shop.setResolverState(shopResolver, null, null);
 
     if (BuildingCreateShop.isDebugRequests()) {
       TheSettlerXCreate.LOGGER.info(
@@ -87,9 +68,7 @@ final class ShopResolverFactory {
           shop.getLocation().getInDimensionLocation(),
           builder.build().size());
       TheSettlerXCreate.LOGGER.info(
-          "[CreateShop] delivery resolver token={} pickup resolver token={}",
-          deliveryResolverToken,
-          pickupResolverToken);
+          "[CreateShop] deliverymen resolvers skipped for CreateShop; real warehouses own courier tasks");
     }
 
     return builder.build();

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrar.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrar.java
@@ -1,9 +1,8 @@
 package com.thesettler_x_create.minecolonies.building;
 
 import com.minecolonies.api.colony.IColony;
-import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 
-/** Maintains Create Shop registration in the MineColonies warehouse list. */
+/** Ensures Create Shop is not treated as a courier warehouse by MineColonies. */
 final class ShopWarehouseRegistrar {
   private final BuildingCreateShop shop;
 
@@ -24,18 +23,7 @@ final class ShopWarehouseRegistrar {
     if (warehouses == null) {
       return;
     }
-    if (!hasWarehouseModules()) {
-      warehouses.remove(shop);
-      shop.warehouseRegistered = false;
-      return;
-    }
-    if (!warehouses.contains(shop)) {
-      warehouses.add(shop);
-    }
-    shop.warehouseRegistered = true;
-  }
-
-  boolean hasWarehouseModules() {
-    return shop.getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE) != null;
+    warehouses.remove(shop);
+    shop.warehouseRegistered = false;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrar.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrar.java
@@ -23,7 +23,7 @@ final class ShopWarehouseRegistrar {
     if (warehouses == null) {
       return;
     }
-    warehouses.remove(shop);
+    warehouses.removeIf(warehouse -> warehouse == shop);
     shop.warehouseRegistered = false;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopAddressModuleWindow.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopAddressModuleWindow.java
@@ -13,7 +13,6 @@ import net.neoforged.neoforge.network.PacketDistributor;
 public class CreateShopAddressModuleWindow
     extends AbstractModuleWindow<CreateShopAddressModuleView> {
   private final com.minecolonies.api.colony.buildings.views.IBuildingView building;
-  private final CreateShopAddressModuleView moduleView;
   private final TextField addressInput;
 
   public CreateShopAddressModuleWindow(CreateShopAddressModuleView moduleView) {
@@ -22,7 +21,6 @@ public class CreateShopAddressModuleWindow
         ResourceLocation.fromNamespaceAndPath(
             TheSettlerXCreate.MODID, "gui/layouthuts/layoutcreateshop_address.xml"));
     this.building = moduleView.getBuildingView();
-    this.moduleView = moduleView;
 
     Text desc = findPaneOfTypeByID("desc", Text.class);
     if (desc != null) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopOutputModuleWindow.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopOutputModuleWindow.java
@@ -8,14 +8,11 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 
 public class CreateShopOutputModuleWindow extends AbstractModuleWindow<CreateShopOutputModuleView> {
-  private final CreateShopOutputModuleView moduleView;
-
   public CreateShopOutputModuleWindow(CreateShopOutputModuleView moduleView) {
     super(
         moduleView,
         ResourceLocation.fromNamespaceAndPath(
             TheSettlerXCreate.MODID, "gui/layouthuts/layoutcreateshop_output.xml"));
-    this.moduleView = moduleView;
 
     Text desc = findPaneOfTypeByID("desc", Text.class);
     if (desc != null) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopTaskModuleWindow.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopTaskModuleWindow.java
@@ -1,0 +1,221 @@
+package com.thesettler_x_create.minecolonies.client.gui;
+
+import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.PaneBuilders;
+import com.ldtteam.blockui.controls.ItemIcon;
+import com.ldtteam.blockui.controls.Text;
+import com.ldtteam.blockui.views.ScrollingList;
+import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.IStackBasedTask;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.IDeliverymanRequestable;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.core.client.gui.AbstractModuleWindow;
+import com.thesettler_x_create.TheSettlerXCreate;
+import com.thesettler_x_create.minecolonies.moduleview.CreateShopTaskModuleView;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+/** Task tab window that also renders icons for standard stack requests. */
+public class CreateShopTaskModuleWindow extends AbstractModuleWindow<CreateShopTaskModuleView> {
+  private static final String LIST_TASKS = "tasks";
+  private static final String REQUESTER = "requester";
+  private static final String DETAIL_ICON = "detailIcon";
+  private static final String SHORT_DETAIL = "shortDetail";
+  private static final String PRIORITY = "priority";
+
+  public CreateShopTaskModuleWindow(CreateShopTaskModuleView moduleView) {
+    super(
+        moduleView,
+        ResourceLocation.fromNamespaceAndPath(
+            TheSettlerXCreate.MODID, "gui/layouthuts/layoutcreateshop_tasklist.xml"));
+  }
+
+  @Override
+  public void onOpened() {
+    super.onOpened();
+    ScrollingList tasks = findPaneOfTypeByID(LIST_TASKS, ScrollingList.class);
+    if (tasks != null) {
+      tasks.setDataProvider(new TaskDataProvider(moduleView.getTasks()));
+    }
+  }
+
+  private final class TaskDataProvider implements ScrollingList.DataProvider {
+    private final List<IToken<?>> tasks;
+    private final List<IToken<?>> visibleTasks = new ArrayList<>();
+
+    private TaskDataProvider(List<IToken<?>> tasks) {
+      this.tasks = tasks;
+    }
+
+    @Override
+    public int getElementCount() {
+      refreshVisibleTasks();
+      return visibleTasks.size();
+    }
+
+    @Override
+    public void updateElement(int index, Pane row) {
+      IRequestManager manager = buildingView.getColony().getRequestManager();
+      if (index >= visibleTasks.size()) {
+        refreshVisibleTasks();
+      }
+      if (index >= visibleTasks.size()) {
+        return;
+      }
+
+      IRequest<?> request = requestFor(manager, visibleTasks.get(index));
+      if (request == null) {
+        return;
+      }
+
+      updateRequester(row, manager, request);
+      updateDetail(row, request);
+      updatePriority(row, request);
+    }
+
+    private void refreshVisibleTasks() {
+      IRequestManager manager = buildingView.getColony().getRequestManager();
+      tasks.removeIf(token -> requestFor(manager, token) == null);
+
+      Set<IToken<?>> allTokens = new HashSet<>(tasks);
+      visibleTasks.clear();
+      for (IToken<?> token : tasks) {
+        IRequest<?> request = requestFor(manager, token);
+        if (request == null || isDeliveryChildHidden(request, allTokens)) {
+          continue;
+        }
+        visibleTasks.add(token);
+      }
+    }
+
+    private boolean isDeliveryChildHidden(IRequest<?> request, Set<IToken<?>> allTokens) {
+      return request.getRequest() instanceof Delivery
+          && request.hasParent()
+          && allTokens.contains(request.getParent());
+    }
+  }
+
+  private void updateRequester(Pane row, IRequestManager manager, IRequest<?> request) {
+    Text requesterText = row.findPaneOfTypeByID(REQUESTER, Text.class);
+    if (requesterText == null) {
+      return;
+    }
+
+    IRequest<?> parent = displayParent(manager, request);
+    Component requesterName = request.getRequester().getRequesterDisplayName(manager, request);
+    if (parent == null) {
+      requesterText.setText(requesterName);
+      return;
+    }
+
+    Component parentName = parent.getRequester().getRequesterDisplayName(manager, parent);
+    requesterText.setText(
+        Component.literal(requesterName.getString() + " -> " + parentName.getString()));
+    PaneBuilders.tooltipBuilder()
+        .hoverPane(requesterText)
+        .build()
+        .setText(
+            Component.literal(
+                request.getRequester().getLocation().getInDimensionLocation().toShortString()
+                    + " -> "
+                    + parent
+                        .getRequester()
+                        .getLocation()
+                        .getInDimensionLocation()
+                        .toShortString()));
+  }
+
+  private IRequest<?> displayParent(IRequestManager manager, IRequest<?> request) {
+    IRequest<?> parent = request.hasParent() ? requestFor(manager, request.getParent()) : null;
+    while (parent != null && sameRequesterLocation(parent, request) && parent.hasParent()) {
+      IRequest<?> nextParent = requestFor(manager, parent.getParent());
+      if (nextParent == null) {
+        break;
+      }
+      parent = nextParent;
+    }
+    return parent;
+  }
+
+  private boolean sameRequesterLocation(IRequest<?> left, IRequest<?> right) {
+    return left.getRequester().getLocation().equals(right.getRequester().getLocation());
+  }
+
+  private void updateDetail(Pane row, IRequest<?> request) {
+    ItemIcon detailIcon = row.findPaneOfTypeByID(DETAIL_ICON, ItemIcon.class);
+    Text shortDetail = row.findPaneOfTypeByID(SHORT_DETAIL, Text.class);
+    if (detailIcon == null || shortDetail == null) {
+      return;
+    }
+
+    if (request instanceof IStackBasedTask stackBasedTask) {
+      ItemStack stack = stackBasedTask.getTaskStack().copy();
+      stack.setCount(stackBasedTask.getDisplayCount());
+      detailIcon.setItem(stack);
+      detailIcon.setVisible(true);
+      shortDetail.setText(stackBasedTask.getDisplayPrefix().withStyle(detailColor(request)));
+      return;
+    }
+
+    setDisplayStackIcon(detailIcon, request);
+    shortDetail.setText(
+        Component.literal(sanitize(request.getShortDisplayString().getString()))
+            .withStyle(detailColor(request)));
+  }
+
+  private void setDisplayStackIcon(ItemIcon detailIcon, IRequest<?> request) {
+    List<ItemStack> stacks = request.getDisplayStacks();
+    if (stacks.isEmpty() || stacks.get(0).isEmpty()) {
+      detailIcon.setVisible(false);
+      return;
+    }
+
+    detailIcon.setItem(stacks.get(0).copy());
+    detailIcon.setVisible(true);
+  }
+
+  private ChatFormatting detailColor(IRequest<?> request) {
+    return request.getState() == RequestState.IN_PROGRESS
+        ? ChatFormatting.DARK_GREEN
+        : ChatFormatting.BLACK;
+  }
+
+  private String sanitize(String value) {
+    return value.replace("\u5442", "");
+  }
+
+  private void updatePriority(Pane row, IRequest<?> request) {
+    Text priority = row.findPaneOfTypeByID(PRIORITY, Text.class);
+    if (priority == null) {
+      return;
+    }
+
+    if (request.getRequest() instanceof IDeliverymanRequestable delivery) {
+      priority.setText(
+          Component.translatable("com.minecolonies.coremod.gui.workerhuts.deliveryman.priority")
+              .append(String.valueOf(delivery.getPriority())));
+    } else {
+      priority.setText(Component.empty());
+    }
+  }
+
+  private IRequest<?> requestFor(IRequestManager manager, IToken<?> token) {
+    if (token == null) {
+      return null;
+    }
+    try {
+      return manager.getRequestForToken(token);
+    } catch (IllegalArgumentException ignored) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/command/CreateShopMaintenanceCommands.java
@@ -1812,7 +1812,6 @@ public final class CreateShopMaintenanceCommands {
   }
 
   private static final class HarnessShopContext {
-    final IColony colony;
     final BuildingCreateShop shop;
     final TileEntityCreateShop tile;
     final CreateShopBlockEntity pickup;
@@ -1822,7 +1821,6 @@ public final class CreateShopMaintenanceCommands {
         BuildingCreateShop shop,
         TileEntityCreateShop tile,
         CreateShopBlockEntity pickup) {
-      this.colony = colony;
       this.shop = shop;
       this.tile = tile;
       this.pickup = pickup;

--- a/src/main/java/com/thesettler_x_create/minecolonies/debug/NativeRequestFlowDiagnostics.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/debug/NativeRequestFlowDiagnostics.java
@@ -208,7 +208,6 @@ public final class NativeRequestFlowDiagnostics {
     return children.isEmpty() ? "-" : String.join(",", children);
   }
 
-  @SuppressWarnings("unchecked")
   private IRequest<?> resolveRequest(Object handler, IToken<?> token) {
     if (handler == null || token == null) {
       return null;

--- a/src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java
@@ -1,0 +1,101 @@
+package com.thesettler_x_create.minecolonies.module;
+
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
+import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
+import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
+import com.minecolonies.core.colony.buildings.modules.WarehouseRequestQueueModule;
+import com.thesettler_x_create.minecolonies.building.BuildingCreateShop;
+import com.thesettler_x_create.minecolonies.requestsystem.resolver.CreateShopRequestResolver;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+
+/** Shop task-tab module that extends warehouse queue data with inflight Create Shop parent tokens. */
+public class CreateShopTaskModule extends WarehouseRequestQueueModule {
+  @Override
+  public void serializeToView(RegistryFriendlyByteBuf buf) {
+    super.serializeToView(buf);
+    List<IToken<?>> inflight = getInflightTaskTokens();
+    buf.writeInt(inflight.size());
+    for (IToken<?> token : inflight) {
+      StandardFactoryController.getInstance().serialize(buf, token);
+    }
+  }
+
+  private List<IToken<?>> getInflightTaskTokens() {
+    if (!(building instanceof BuildingCreateShop shop)
+        || shop.getColony() == null
+        || !(shop.getColony().getRequestManager() instanceof IStandardRequestManager manager)) {
+      return List.of();
+    }
+    CreateShopRequestResolver resolver = shop.getOrCreateShopResolver();
+    if (resolver == null || resolver.getId() == null) {
+      return List.of();
+    }
+    IToken<?> resolverId = resolver.getId();
+    var assignmentStore = manager.getRequestResolverRequestAssignmentDataStore();
+    if (assignmentStore == null || assignmentStore.getAssignments() == null) {
+      return List.of();
+    }
+    var assigned = assignmentStore.getAssignments().get(resolverId);
+    if (assigned == null || assigned.isEmpty()) {
+      return List.of();
+    }
+    var requestHandler = manager.getRequestHandler();
+    var resolverHandler = manager.getResolverHandler();
+    if (requestHandler == null || resolverHandler == null) {
+      return List.of();
+    }
+    List<IToken<?>> inflight = new ArrayList<>();
+    for (IToken<?> token : new ArrayList<>(assigned)) {
+      if (token == null) {
+        continue;
+      }
+      try {
+        IRequest<?> request = requestHandler.getRequest(token);
+        if (request == null || request.getRequest() == null) {
+          continue;
+        }
+        if (isTerminalRequestState(request.getState())) {
+          continue;
+        }
+        if (!(request.getRequest() instanceof IDeliverable)
+            || request.getRequest() instanceof Delivery) {
+          continue;
+        }
+        IRequestResolver<?> owner = resolverHandler.getResolverForRequest(request);
+        if (!(owner instanceof CreateShopRequestResolver ownerResolver)
+            || !resolverId.equals(ownerResolver.getId())) {
+          continue;
+        }
+        if (request.getState() != RequestState.IN_PROGRESS && !request.hasChildren()) {
+          continue;
+        }
+        inflight.add(token);
+      } catch (Exception ignored) {
+        // Ignore stale assignment/request links.
+      }
+    }
+    if (inflight.isEmpty()) {
+      return List.of();
+    }
+    return List.copyOf(new LinkedHashSet<>(inflight));
+  }
+
+  private static boolean isTerminalRequestState(RequestState state) {
+    if (state == null) {
+      return false;
+    }
+    return state == RequestState.CANCELLED
+        || state == RequestState.COMPLETED
+        || state == RequestState.FAILED
+        || state == RequestState.RECEIVED
+        || state == RequestState.RESOLVED;
+  }
+}

--- a/src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java
@@ -76,6 +76,9 @@ public class CreateShopTaskModule extends WarehouseRequestQueueModule {
             || !resolverId.equals(ownerResolver.getId())) {
           continue;
         }
+        if (resolver.hasParentChildCompletedSeen(token) && !request.hasChildren()) {
+          continue;
+        }
         if (request.getState() != RequestState.IN_PROGRESS && !request.hasChildren()) {
           continue;
         }

--- a/src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java
@@ -1,14 +1,14 @@
 package com.thesettler_x_create.minecolonies.module;
 
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
 import com.minecolonies.api.colony.requestsystem.resolver.IRequestResolver;
-import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
-import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
 import com.minecolonies.core.colony.buildings.modules.WarehouseRequestQueueModule;
+import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
 import com.thesettler_x_create.minecolonies.building.BuildingCreateShop;
 import com.thesettler_x_create.minecolonies.requestsystem.resolver.CreateShopRequestResolver;
 import java.util.ArrayList;
@@ -16,7 +16,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 
-/** Shop task-tab module that extends warehouse queue data with inflight Create Shop parent tokens. */
+/**
+ * Shop task-tab module that extends warehouse queue data with inflight Create Shop parent tokens.
+ */
 public class CreateShopTaskModule extends WarehouseRequestQueueModule {
   @Override
   public void serializeToView(RegistryFriendlyByteBuf buf) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopTaskModuleView.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopTaskModuleView.java
@@ -1,0 +1,45 @@
+package com.thesettler_x_create.minecolonies.moduleview;
+
+import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.minecolonies.core.colony.buildings.moduleviews.RequestTaskModuleView;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import org.jetbrains.annotations.NotNull;
+
+/** Task-tab view for Create Shop that merges warehouse queue and inflight parent request tokens. */
+public class CreateShopTaskModuleView extends RequestTaskModuleView {
+  private final List<IToken<?>> tasks = new ArrayList<>();
+
+  @Override
+  public List<IToken<?>> getTasks() {
+    return tasks;
+  }
+
+  @Override
+  public void deserialize(@NotNull RegistryFriendlyByteBuf buf) {
+    tasks.clear();
+    super.deserialize(buf);
+    int queueSize = buf.readInt();
+    for (int i = 0; i < queueSize; i++) {
+      IToken<?> token = StandardFactoryController.getInstance().deserialize(buf);
+      if (token != null) {
+        tasks.add(token);
+      }
+    }
+    int extra = buf.readInt();
+    for (int i = 0; i < extra; i++) {
+      IToken<?> token = StandardFactoryController.getInstance().deserialize(buf);
+      if (token != null) {
+        tasks.add(token);
+      }
+    }
+    if (!tasks.isEmpty()) {
+      LinkedHashSet<IToken<?>> deduped = new LinkedHashSet<>(tasks);
+      tasks.clear();
+      tasks.addAll(deduped);
+    }
+  }
+}

--- a/src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopTaskModuleView.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopTaskModuleView.java
@@ -1,8 +1,10 @@
 package com.thesettler_x_create.minecolonies.moduleview;
 
+import com.ldtteam.blockui.views.BOWindow;
 import com.minecolonies.api.colony.requestsystem.StandardFactoryController;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.core.colony.buildings.moduleviews.RequestTaskModuleView;
+import com.thesettler_x_create.minecolonies.client.gui.CreateShopTaskModuleWindow;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -16,6 +18,11 @@ public class CreateShopTaskModuleView extends RequestTaskModuleView {
   @Override
   public List<IToken<?>> getTasks() {
     return tasks;
+  }
+
+  @Override
+  public BOWindow getWindow() {
+    return new CreateShopTaskModuleWindow(this);
   }
 
   @Override

--- a/src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java
@@ -5,7 +5,6 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry.ModuleProducer;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.apiimp.CommonMinecoloniesAPIImpl;
-import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.core.colony.buildings.views.EmptyView;
@@ -16,10 +15,12 @@ import com.thesettler_x_create.minecolonies.module.CreateShopAddressModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopOutputModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopPermaModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopStockModule;
+import com.thesettler_x_create.minecolonies.module.CreateShopTaskModule;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopAddressModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopOutputModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopPermaModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopStockModuleView;
+import com.thesettler_x_create.minecolonies.moduleview.CreateShopTaskModuleView;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -53,7 +54,11 @@ public final class ModMinecoloniesBuildings {
                                   true,
                                   building -> 1),
                           () -> WorkerBuildingModuleView::new))
-                  .addBuildingModuleProducer(BuildingModules.WAREHOUSE_REQUEST_QUEUE)
+                  .addBuildingModuleProducer(
+                      new ModuleProducer<>(
+                          "warehouse_request_queue",
+                          CreateShopTaskModule::new,
+                          () -> CreateShopTaskModuleView::new))
                   .addBuildingModuleProducer(
                       new ModuleProducer<>(
                           "createshop_address",

--- a/src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java
@@ -5,6 +5,7 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry.ModuleProducer;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.apiimp.CommonMinecoloniesAPIImpl;
+import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.core.colony.buildings.views.EmptyView;
@@ -15,12 +16,10 @@ import com.thesettler_x_create.minecolonies.module.CreateShopAddressModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopOutputModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopPermaModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopStockModule;
-import com.thesettler_x_create.minecolonies.module.CreateShopTaskModule;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopAddressModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopOutputModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopPermaModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopStockModuleView;
-import com.thesettler_x_create.minecolonies.moduleview.CreateShopTaskModuleView;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -54,11 +53,7 @@ public final class ModMinecoloniesBuildings {
                                   true,
                                   building -> 1),
                           () -> WorkerBuildingModuleView::new))
-                  .addBuildingModuleProducer(
-                      new ModuleProducer<>(
-                          "warehouse_request_queue",
-                          CreateShopTaskModule::new,
-                          () -> CreateShopTaskModuleView::new))
+                  .addBuildingModuleProducer(BuildingModules.WAREHOUSE_REQUEST_QUEUE)
                   .addBuildingModuleProducer(
                       new ModuleProducer<>(
                           "createshop_address",

--- a/src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java
@@ -5,7 +5,6 @@ import com.minecolonies.api.colony.buildings.registry.BuildingEntry;
 import com.minecolonies.api.colony.buildings.registry.BuildingEntry.ModuleProducer;
 import com.minecolonies.api.entity.citizen.Skill;
 import com.minecolonies.apiimp.CommonMinecoloniesAPIImpl;
-import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.WorkerBuildingModule;
 import com.minecolonies.core.colony.buildings.moduleviews.WorkerBuildingModuleView;
 import com.minecolonies.core.colony.buildings.views.EmptyView;
@@ -16,10 +15,12 @@ import com.thesettler_x_create.minecolonies.module.CreateShopAddressModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopOutputModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopPermaModule;
 import com.thesettler_x_create.minecolonies.module.CreateShopStockModule;
+import com.thesettler_x_create.minecolonies.module.CreateShopTaskModule;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopAddressModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopOutputModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopPermaModuleView;
 import com.thesettler_x_create.minecolonies.moduleview.CreateShopStockModuleView;
+import com.thesettler_x_create.minecolonies.moduleview.CreateShopTaskModuleView;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -53,7 +54,11 @@ public final class ModMinecoloniesBuildings {
                                   true,
                                   building -> 1),
                           () -> WorkerBuildingModuleView::new))
-                  .addBuildingModuleProducer(BuildingModules.WAREHOUSE_REQUEST_QUEUE)
+                  .addBuildingModuleProducer(
+                      new ModuleProducer<>(
+                          "createshop_request_queue",
+                          CreateShopTaskModule::new,
+                          () -> CreateShopTaskModuleView::new))
                   .addBuildingModuleProducer(
                       new ModuleProducer<>(
                           "createshop_address",

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/requesters/CreateShopDeliveryRequester.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/requesters/CreateShopDeliveryRequester.java
@@ -1,0 +1,72 @@
+package com.thesettler_x_create.minecolonies.requestsystem.requesters;
+
+import com.minecolonies.api.colony.requestsystem.location.ILocation;
+import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
+import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.requester.IRequester;
+import com.minecolonies.api.colony.requestsystem.token.IToken;
+import com.thesettler_x_create.minecolonies.requestsystem.resolver.CreateShopRequestResolver;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+
+/**
+ * Delivery requester for Create Shop sourced deliveries.
+ *
+ * <p>The delegate stays the native warehouse requester so MineColonies assigns and displays the
+ * task in the target warehouse queue. The display name is the Create Shop source, matching the
+ * delivery payload's start location.
+ */
+public final class CreateShopDeliveryRequester implements IRequester {
+  private final IRequester delegate;
+  private final ILocation sourceLocation;
+
+  public CreateShopDeliveryRequester(IRequester delegate) {
+    this(delegate, null);
+  }
+
+  public CreateShopDeliveryRequester(IRequester delegate, ILocation sourceLocation) {
+    this.delegate = delegate;
+    this.sourceLocation = sourceLocation;
+  }
+
+  public IRequester getDelegate() {
+    return delegate;
+  }
+
+  public ILocation getSourceLocation() {
+    return sourceLocation;
+  }
+
+  @Override
+  public IToken<?> getId() {
+    return delegate == null ? null : delegate.getId();
+  }
+
+  @Override
+  public ILocation getLocation() {
+    return sourceLocation == null
+        ? (delegate == null ? null : delegate.getLocation())
+        : sourceLocation;
+  }
+
+  @Override
+  public void onRequestedRequestComplete(IRequestManager manager, IRequest<?> request) {
+    CreateShopRequestResolver.onDeliveryComplete(manager, request);
+    if (delegate != null) {
+      delegate.onRequestedRequestComplete(manager, request);
+    }
+  }
+
+  @Override
+  public void onRequestedRequestCancelled(IRequestManager manager, IRequest<?> request) {
+    CreateShopRequestResolver.onDeliveryCancelled(manager, request);
+    if (delegate != null) {
+      delegate.onRequestedRequestCancelled(manager, request);
+    }
+  }
+
+  @Override
+  public MutableComponent getRequesterDisplayName(IRequestManager manager, IRequest<?> request) {
+    return Component.translatable("com.thesettler_x_create.coremod.buildings.createshop");
+  }
+}

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/requesters/CreateShopDeliveryRequesterFactory.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/requesters/CreateShopDeliveryRequesterFactory.java
@@ -1,0 +1,99 @@
+package com.thesettler_x_create.minecolonies.requestsystem.requesters;
+
+import com.google.common.reflect.TypeToken;
+import com.minecolonies.api.colony.requestsystem.factory.IFactoryController;
+import com.minecolonies.api.colony.requestsystem.location.ILocation;
+import com.minecolonies.api.colony.requestsystem.requester.IRequester;
+import com.minecolonies.api.colony.requestsystem.requester.IRequesterFactory;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+
+/** Factory for Create Shop delivery requester wrappers. */
+public class CreateShopDeliveryRequesterFactory
+    implements IRequesterFactory<IRequester, CreateShopDeliveryRequester> {
+  private static final String TAG_DELEGATE = "Delegate";
+  private static final String TAG_SOURCE_LOCATION = "SourceLocation";
+  private static final short SERIALIZATION_ID = 3002;
+
+  @Override
+  public TypeToken<? extends CreateShopDeliveryRequester> getFactoryOutputType() {
+    return TypeToken.of(CreateShopDeliveryRequester.class);
+  }
+
+  @Override
+  public TypeToken<? extends IRequester> getFactoryInputType() {
+    return TypeToken.of(IRequester.class);
+  }
+
+  @Override
+  public CreateShopDeliveryRequester getNewInstance(
+      IFactoryController factoryController, IRequester input, Object... context)
+      throws IllegalArgumentException {
+    if (input instanceof CreateShopDeliveryRequester requester) {
+      return requester;
+    }
+    return new CreateShopDeliveryRequester(input);
+  }
+
+  @Override
+  public CompoundTag serialize(
+      HolderLookup.Provider registries,
+      IFactoryController factoryController,
+      CreateShopDeliveryRequester requester) {
+    CompoundTag tag = new CompoundTag();
+    if (requester == null) {
+      return tag;
+    }
+    if (requester.getDelegate() != null) {
+      tag.put(TAG_DELEGATE, factoryController.serializeTag(registries, requester.getDelegate()));
+    }
+    if (requester.getSourceLocation() != null) {
+      tag.put(
+          TAG_SOURCE_LOCATION,
+          factoryController.serializeTag(registries, requester.getSourceLocation()));
+    }
+    return tag;
+  }
+
+  @Override
+  public CreateShopDeliveryRequester deserialize(
+      HolderLookup.Provider registries, IFactoryController factoryController, CompoundTag tag) {
+    IRequester delegate = null;
+    if (tag != null && tag.contains(TAG_DELEGATE)) {
+      delegate =
+          (IRequester) factoryController.deserializeTag(registries, tag.getCompound(TAG_DELEGATE));
+    }
+    ILocation sourceLocation = null;
+    if (tag != null && tag.contains(TAG_SOURCE_LOCATION)) {
+      sourceLocation =
+          (ILocation)
+              factoryController.deserializeTag(registries, tag.getCompound(TAG_SOURCE_LOCATION));
+    }
+    return new CreateShopDeliveryRequester(delegate, sourceLocation);
+  }
+
+  @Override
+  public void serialize(
+      IFactoryController factoryController,
+      CreateShopDeliveryRequester requester,
+      RegistryFriendlyByteBuf buffer) {
+    IRequester delegate = requester == null ? null : requester.getDelegate();
+    ILocation sourceLocation = requester == null ? null : requester.getSourceLocation();
+    factoryController.serialize(buffer, delegate);
+    factoryController.serialize(buffer, sourceLocation);
+  }
+
+  @Override
+  public CreateShopDeliveryRequester deserialize(
+      IFactoryController factoryController, RegistryFriendlyByteBuf buffer) throws Throwable {
+    IRequester delegate = (IRequester) factoryController.deserialize(buffer);
+    ILocation sourceLocation = (ILocation) factoryController.deserialize(buffer);
+    return new CreateShopDeliveryRequester(delegate, sourceLocation);
+  }
+
+  @Override
+  public short getSerializationId() {
+    return SERIALIZATION_ID;
+  }
+}

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopChildReconciliationService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopChildReconciliationService.java
@@ -140,19 +140,19 @@ final class CreateShopChildReconciliationService {
               }
             }
             if (childAssigned == null) {
-              boolean enqueued = deliveryManager.tryEnqueueDelivery(standardManager, childToken);
+              boolean assigned = deliveryManager.assignDeliveryRequest(standardManager, childToken);
+              boolean queued = deliveryManager.isQueuedInWarehouse(standardManager, childToken);
               if (Config.DEBUG_LOGGING.getAsBoolean()) {
                 TheSettlerXCreate.LOGGER.info(
-                    "[CreateShop] tickPending: {} child {} unassigned delivery -> enqueue={}",
+                    "[CreateShop] tickPending: {} child {} unassigned delivery -> assign={} queue={}",
                     requestIdLog,
                     childToken,
-                    enqueued ? "ok" : "none");
+                    assigned ? "ok" : "none",
+                    queued ? "present" : "missing");
               }
             }
             resolver.observeDeliveryChildLifecycle(
                 standardManager, level, request.getId(), childToken, child, childAssigned, "poll");
-            maybeReleaseReservationOnCourierPickup(
-                resolver, request, pickup, childToken, childState);
             if (activeLocalDeliveryChild != null && !activeLocalDeliveryChild.equals(childToken)) {
               boolean recovered =
                   deliveryChildRecoveryService.recover(
@@ -279,43 +279,6 @@ final class CreateShopChildReconciliationService {
     }
   }
 
-  private void maybeReleaseReservationOnCourierPickup(
-      CreateShopRequestResolver resolver,
-      IRequest<?> parentRequest,
-      CreateShopBlockEntity pickup,
-      IToken<?> childToken,
-      RequestState childState) {
-    if (resolver == null
-        || parentRequest == null
-        || pickup == null
-        || childToken == null
-        || childState != RequestState.IN_PROGRESS) {
-      return;
-    }
-    CreateShopDeliveryChildLedgerEntry ledger = resolver.getDeliveryChildLedgerEntry(childToken);
-    if (ledger == null) {
-      return;
-    }
-    // Confirm pickup via native courier task tracking; carry snapshot is best-effort telemetry
-    // only.
-    if (ledger.getLastCourierTaskMatchCount() <= 0) {
-      return;
-    }
-    UUID parentRequestId = CreateShopRequestResolver.toRequestId(parentRequest.getId());
-    int reserved = pickup.getReservedForRequest(parentRequestId);
-    if (reserved <= 0) {
-      return;
-    }
-    pickup.release(parentRequestId);
-    if (resolver.isDebugLoggingEnabled()) {
-      TheSettlerXCreate.LOGGER.info(
-          "[CreateShop] reservation release on courier pickup parent={} child={} reservedReleased={}",
-          parentRequest.getId(),
-          childToken,
-          reserved);
-    }
-  }
-
   private boolean tryImmediateMissingAfterPickupRecovery(
       CreateShopRequestResolver resolver,
       IStandardRequestManager standardManager,
@@ -338,6 +301,22 @@ final class CreateShopChildReconciliationService {
     }
     if (!parentRequest.getId().equals(ledger.getParentToken())) {
       return false;
+    }
+    BuildingCreateShop shop = resolver.getShop(standardManager);
+    CreateShopBlockEntity pickup = shop == null ? null : shop.getPickupBlockEntity();
+    if (pickup != null) {
+      UUID parentRequestId = CreateShopRequestResolver.toRequestId(parentRequest.getId());
+      int reservedForRequest = pickup.getReservedForRequest(parentRequestId);
+      if (reservedForRequest > 0) {
+        if (resolver.isDebugLoggingEnabled()) {
+          TheSettlerXCreate.LOGGER.info(
+              "[CreateShop] tickPending: {} missing child {} held by reservation={} -> no orphan recovery",
+              requestIdLog,
+              childToken,
+              reservedForRequest);
+        }
+        return false;
+      }
     }
     parentRequest.removeChild(childToken);
     resolver.markParentChildCompletedSeen(parentRequest.getId(), level.getGameTime());

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java
@@ -3,6 +3,7 @@ package com.thesettler_x_create.minecolonies.requestsystem.resolver;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
+import com.minecolonies.api.colony.requestsystem.request.RequestState;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
@@ -147,7 +148,14 @@ final class CreateShopDeliveryCompletionService {
         parentRequest != null
             && !CreateShopRequestResolver.isTerminalRequestState(parentRequest.getState());
     int pending = resolver.getPendingTracker().getPendingCount(parentToken);
-    if (parentStillNonTerminal) {
+    boolean parentResolvedByDelivery =
+        parentStillNonTerminal
+            && pending <= 0
+            && completeParentAfterDeliveredChild(
+                resolver, standard, manager, parentRequest, parentToken, childToken);
+    if (parentResolvedByDelivery) {
+      requestStateMutatorService.clearPendingTokenState(resolver, standard, parentToken, true);
+    } else if (parentStillNonTerminal) {
       int heldPending = Math.max(1, pending);
       requestStateMutatorService.markOrderedWithPendingAtLeastOne(
           resolver, level, parentToken, heldPending);
@@ -188,5 +196,83 @@ final class CreateShopDeliveryCompletionService {
         }
       }
     }
+  }
+
+  private boolean completeParentAfterDeliveredChild(
+      CreateShopRequestResolver resolver,
+      IStandardRequestManager standard,
+      IRequestManager manager,
+      IRequest<?> parentRequest,
+      IToken<?> parentToken,
+      IToken<?> childToken) {
+    if (resolver == null || standard == null || parentRequest == null || parentToken == null) {
+      return false;
+    }
+    detachCompletedChild(standard, parentRequest, childToken);
+    if (hasActiveNonTerminalChild(standard, parentRequest)) {
+      return false;
+    }
+    try {
+      standard.updateRequestState(parentToken, RequestState.RESOLVED);
+      resolver.transitionFlow(
+          manager,
+          parentRequest,
+          CreateShopFlowState.REQUEST_COMPLETED,
+          "delivery-complete:parent-resolved",
+          "",
+          0,
+          "com.thesettler_x_create.message.createshop.flow_request_completed");
+      resolver.releaseReservation(manager, parentRequest);
+      if (resolver.isDebugLoggingEnabled()) {
+        TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] delivery complete resolved parent={} child={}", parentToken, childToken);
+      }
+      return true;
+    } catch (Exception ignored) {
+      return false;
+    }
+  }
+
+  private void detachCompletedChild(
+      IStandardRequestManager standard, IRequest<?> parentRequest, IToken<?> childToken) {
+    if (standard == null || parentRequest == null || childToken == null) {
+      return;
+    }
+    try {
+      IRequest<?> child = standard.getRequestHandler().getRequestOrNull(childToken);
+      if (child != null && CreateShopRequestResolver.isTerminalRequestState(child.getState())) {
+        parentRequest.removeChild(childToken);
+        child.setParent(null);
+      }
+    } catch (Exception ignored) {
+      // Best effort: parent resolution below still checks for active children.
+    }
+  }
+
+  private boolean hasActiveNonTerminalChild(
+      IStandardRequestManager standard, IRequest<?> parentRequest) {
+    if (standard == null || parentRequest == null || !parentRequest.hasChildren()) {
+      return false;
+    }
+    for (IToken<?> childToken : java.util.List.copyOf(parentRequest.getChildren())) {
+      if (childToken == null) {
+        continue;
+      }
+      try {
+        IRequest<?> child = standard.getRequestHandler().getRequestOrNull(childToken);
+        if (child == null) {
+          return true;
+        }
+        if (CreateShopRequestResolver.isTerminalRequestState(child.getState())) {
+          parentRequest.removeChild(childToken);
+          child.setParent(null);
+          continue;
+        }
+        return true;
+      } catch (Exception ignored) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java
@@ -4,6 +4,7 @@ import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
 import com.minecolonies.api.colony.requestsystem.request.RequestState;
+import com.minecolonies.api.colony.requestsystem.requestable.IDeliverable;
 import com.minecolonies.api.colony.requestsystem.requestable.deliveryman.Delivery;
 import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
@@ -24,6 +25,8 @@ final class CreateShopDeliveryCompletionService {
   private final CreateShopDeliveryManager deliveryManager;
   private final CreateShopResolverDiagnostics diagnostics;
   private final CreateShopResolverRecheck recheck;
+  private final CreateShopOutstandingNeededService outstandingNeededService =
+      new CreateShopOutstandingNeededService();
 
   CreateShopDeliveryCompletionService(
       CreateShopRequestStateMutatorService requestStateMutatorService,
@@ -150,9 +153,8 @@ final class CreateShopDeliveryCompletionService {
     int pending = resolver.getPendingTracker().getPendingCount(parentToken);
     boolean parentResolvedByDelivery =
         parentStillNonTerminal
-            && pending <= 0
             && completeParentAfterDeliveredChild(
-                resolver, standard, manager, parentRequest, parentToken, childToken);
+                resolver, standard, manager, parentRequest, parentToken, childToken, pending);
     if (parentResolvedByDelivery) {
       requestStateMutatorService.clearPendingTokenState(resolver, standard, parentToken, true);
     } else if (parentStillNonTerminal) {
@@ -204,12 +206,17 @@ final class CreateShopDeliveryCompletionService {
       IRequestManager manager,
       IRequest<?> parentRequest,
       IToken<?> parentToken,
-      IToken<?> childToken) {
+      IToken<?> childToken,
+      int trackedPending) {
     if (resolver == null || standard == null || parentRequest == null || parentToken == null) {
       return false;
     }
     detachCompletedChild(standard, parentRequest, childToken);
     if (hasActiveNonTerminalChild(standard, parentRequest)) {
+      return false;
+    }
+    int outstanding = computeOutstandingAfterDelivery(resolver, manager, parentRequest, parentToken);
+    if (Math.max(0, Math.max(trackedPending, outstanding)) > 0) {
       return false;
     }
     try {
@@ -231,6 +238,28 @@ final class CreateShopDeliveryCompletionService {
     } catch (Exception ignored) {
       return false;
     }
+  }
+
+  private int computeOutstandingAfterDelivery(
+      CreateShopRequestResolver resolver,
+      IRequestManager manager,
+      IRequest<?> parentRequest,
+      IToken<?> parentToken) {
+    if (parentRequest == null || !(parentRequest.getRequest() instanceof IDeliverable deliverable)) {
+      return 0;
+    }
+    int reservedForRequest = 0;
+    try {
+      BuildingCreateShop shop = resolver.getShop(manager);
+      CreateShopBlockEntity pickup = shop == null ? null : shop.getPickupBlockEntity();
+      if (pickup != null) {
+        reservedForRequest =
+            pickup.getReservedForRequest(CreateShopRequestResolver.toRequestId(parentToken));
+      }
+    } catch (Exception ignored) {
+      reservedForRequest = 0;
+    }
+    return outstandingNeededService.compute(parentRequest, deliverable, reservedForRequest);
   }
 
   private void detachCompletedChild(

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerService.java
@@ -85,6 +85,25 @@ final class CreateShopDeliveryLifecycleLedgerService {
       }
     }
     if (state == RequestState.IN_PROGRESS
+        && snapshot.queueContains()
+        && snapshot.courierCount() > 0
+        && snapshot.courierTaskMatchCount() <= 0) {
+      int nudged = CreateShopDeliveryManager.nudgeDeliverymen(manager, childToken);
+      if (nudged > 0) {
+        entry.setDiagnosisCode("COURIER_QUEUE_HANDOFF_REPAIRED");
+        entry.setDiagnosisDetail("warehouse queue handoff repaired count=" + nudged);
+        snapshot =
+            inspectWarehouseSnapshot(
+                manager, childToken, deliveryStack, deliveryStart, deliveryTarget);
+        entry.setLastQueueContains(snapshot.queueContains());
+        entry.setLastCourierCount(snapshot.courierCount());
+        entry.setLastCourierTaskMatchCount(snapshot.courierTaskMatchCount());
+        entry.setLastCourierCarryMatchCount(snapshot.courierCarryMatchCount());
+        entry.setLastCourierAtSourceMatchCount(snapshot.courierAtSourceMatchCount());
+        entry.setLastCourierAtTargetMatchCount(snapshot.courierAtTargetMatchCount());
+      }
+    }
+    if (state == RequestState.IN_PROGRESS
         && !snapshot.queueContains()
         && snapshot.courierTaskMatchCount() > 0
         && snapshot.courierAtTargetMatchCount() > 0) {

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerService.java
@@ -90,8 +90,8 @@ final class CreateShopDeliveryLifecycleLedgerService {
         && snapshot.courierTaskMatchCount() <= 0) {
       int nudged = CreateShopDeliveryManager.nudgeDeliverymen(manager, childToken);
       if (nudged > 0) {
-        entry.setDiagnosisCode("COURIER_QUEUE_HANDOFF_REPAIRED");
-        entry.setDiagnosisDetail("warehouse queue handoff repaired count=" + nudged);
+        entry.setDiagnosisCode("COURIER_QUEUE_HANDOFF_PENDING");
+        entry.setDiagnosisDetail("warehouse queue handoff pending couriers=" + nudged);
         snapshot =
             inspectWarehouseSnapshot(
                 manager, childToken, deliveryStack, deliveryStart, deliveryTarget);

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
@@ -234,11 +234,11 @@ final class CreateShopDeliveryManager {
           "create",
           manager,
           token,
-          resolver.toRequestId(request.getId()),
+          CreateShopRequestResolver.toRequestId(request.getId()),
           startPos,
           selected.copy(),
           request.getRequester().getLocation(),
-          pickup.getReservedForRequest(resolver.toRequestId(request.getId())),
+          pickup.getReservedForRequest(CreateShopRequestResolver.toRequestId(request.getId())),
           reservedForDeliverable,
           pickup.getReservedFor(selected));
       IStandardRequestManager standardManager =

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
@@ -1,7 +1,6 @@
 package com.thesettler_x_create.minecolonies.requestsystem.resolver;
 
 import com.google.common.collect.Lists;
-import com.minecolonies.api.colony.buildings.workerbuildings.IWareHouse;
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
 import com.minecolonies.api.colony.requestsystem.manager.IRequestManager;
 import com.minecolonies.api.colony.requestsystem.request.IRequest;
@@ -13,17 +12,19 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.api.tileentities.AbstractTileEntityRack;
 import com.minecolonies.api.util.WorldUtil;
 import com.minecolonies.api.util.constant.TypeConstants;
-import com.minecolonies.core.colony.buildings.modules.AbstractAssignedCitizenModule;
 import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.CourierAssignmentModule;
-import com.minecolonies.core.colony.buildings.modules.DeliverymanAssignmentModule;
 import com.minecolonies.core.colony.buildings.modules.WarehouseRequestQueueModule;
+import com.minecolonies.core.colony.jobs.JobDeliveryman;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
+import com.minecolonies.core.colony.requestsystem.resolvers.DeliveryRequestResolver;
 import com.minecolonies.core.colony.requestsystem.resolvers.core.AbstractWarehouseRequestResolver;
 import com.thesettler_x_create.Config;
 import com.thesettler_x_create.TheSettlerXCreate;
 import com.thesettler_x_create.blockentity.CreateShopBlockEntity;
 import com.thesettler_x_create.minecolonies.building.BuildingCreateShop;
+import com.thesettler_x_create.minecolonies.requestsystem.requesters.CreateShopDeliveryRequester;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
@@ -113,7 +114,7 @@ final class CreateShopDeliveryManager {
             targetLocation,
             selected.copy(),
             AbstractDeliverymanRequestable.getDefaultDeliveryPriority(true));
-    IRequester deliveryRequester = resolveDeliveryRequester(manager, request);
+    IRequester deliveryRequester = resolveDeliveryRequester(manager, request, pickupLocation);
     IToken<?> token;
     try {
       token = manager.createRequest(deliveryRequester, delivery);
@@ -219,12 +220,14 @@ final class CreateShopDeliveryManager {
         }
       }
     }
-    boolean enqueued = tryEnqueueDelivery(manager, token);
+    boolean assigned = assignDeliveryRequest(manager, token);
+    boolean queued = isQueuedInWarehouse(manager, token);
     if (Config.DEBUG_LOGGING.getAsBoolean()) {
       TheSettlerXCreate.LOGGER.info(
-          "[CreateShop] delivery native dispatch token={} viaWarehouseQueue={}",
+          "[CreateShop] delivery native dispatch token={} assign={} warehouseQueue={}",
           token,
-          enqueued ? "ok" : "none");
+          assigned ? "ok" : "none",
+          queued ? "present" : "missing");
     }
     if (Config.DEBUG_LOGGING.getAsBoolean()) {
       IDeliverable deliverable = request.getRequest() instanceof IDeliverable typed ? typed : null;
@@ -260,16 +263,76 @@ final class CreateShopDeliveryManager {
         // Best-effort diagnostics only.
       }
     }
-    notifyDeliverymen(manager, token);
+    nudgeDeliverymen(manager, token);
     return Lists.newArrayList(token);
   }
 
-  private IRequester resolveDeliveryRequester(IRequestManager manager, IRequest<?> parentRequest) {
+  boolean assignDeliveryRequest(IRequestManager manager, IToken<?> token) {
+    if (manager == null || token == null) {
+      return false;
+    }
+    try {
+      if (manager instanceof IStandardRequestManager standard) {
+        IRequest<?> request = standard.getRequestHandler().getRequestOrNull(token);
+        Collection<IToken<?>> blacklist = getCreateShopDeliveryResolverBlacklist(standard);
+        if (request != null && !blacklist.isEmpty()) {
+          return standard.getRequestHandler().assignRequest(request, blacklist) != null;
+        }
+      }
+      manager.assignRequest(token);
+      return true;
+    } catch (Exception ex) {
+      if (Config.DEBUG_LOGGING.getAsBoolean()) {
+        TheSettlerXCreate.LOGGER.info(
+            "[CreateShop] delivery assign immediate token={} result=failed error={}",
+            token,
+            ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+      }
+      return false;
+    }
+  }
+
+  private Collection<IToken<?>> getCreateShopDeliveryResolverBlacklist(
+      IStandardRequestManager standard) {
+    java.util.List<IToken<?>> blacklist = new java.util.ArrayList<>();
+    try {
+      var typeStore = standard.getRequestableTypeRequestResolverAssignmentDataStore();
+      var assignments = typeStore == null ? null : typeStore.getAssignments();
+      var requestableResolvers =
+          assignments == null ? null : assignments.get(TypeConstants.REQUESTABLE);
+      if (requestableResolvers == null) {
+        return blacklist;
+      }
+      for (IToken<?> resolverToken : requestableResolvers) {
+        try {
+          var candidate = standard.getResolverHandler().getResolver(resolverToken);
+          if (!(candidate instanceof DeliveryRequestResolver deliveryResolver)
+              || deliveryResolver.getLocation() == null) {
+            continue;
+          }
+          BlockPos resolverPos = deliveryResolver.getLocation().getInDimensionLocation();
+          var building =
+              standard.getColony().getServerBuildingManager().getBuilding(resolverPos);
+          if (building instanceof BuildingCreateShop) {
+            blacklist.add(resolverToken);
+          }
+        } catch (Exception ignored) {
+          // Ignore stale resolver ids.
+        }
+      }
+    } catch (Exception ignored) {
+      // Best effort.
+    }
+    return blacklist;
+  }
+
+  private IRequester resolveDeliveryRequester(
+      IRequestManager manager, IRequest<?> parentRequest, ILocation sourceLocation) {
     if (manager instanceof IStandardRequestManager standard) {
       try {
         var owner = standard.getResolverHandler().getResolverForRequest(parentRequest);
         if (isWarehouseDeliveryResolver(owner) && owner instanceof IRequester requester) {
-          return requester;
+          return new CreateShopDeliveryRequester(requester, sourceLocation);
         }
       } catch (Exception ignored) {
         // Best effort.
@@ -285,7 +348,7 @@ final class CreateShopDeliveryManager {
               var candidate = standard.getResolverHandler().getResolver(resolverToken);
               if (isWarehouseDeliveryResolver(candidate)
                   && candidate instanceof IRequester requester) {
-                return requester;
+                return new CreateShopDeliveryRequester(requester, sourceLocation);
               }
             } catch (Exception ignored) {
               // Ignore stale resolver ids.
@@ -387,7 +450,7 @@ final class CreateShopDeliveryManager {
         targetBlock);
   }
 
-  boolean tryEnqueueDelivery(IRequestManager manager, IToken<?> token) {
+  boolean isQueuedInWarehouse(IRequestManager manager, IToken<?> token) {
     if (manager == null || token == null) {
       return false;
     }
@@ -396,26 +459,14 @@ final class CreateShopDeliveryManager {
       return false;
     }
     int warehousesChecked = 0;
-    int warehousesWithCouriers = 0;
     int warehousesWithQueue = 0;
     for (var entry : buildingManager.getBuildings().entrySet()) {
       if (entry.getValue() instanceof BuildingCreateShop) {
-        // The shop is IRequester/IWareHouse for MineColonies integration, but must never be used as
-        // a deliveryman source.
-        continue;
-      }
-      if (!(entry.getValue() instanceof IWareHouse warehouse)) {
         continue;
       }
       warehousesChecked++;
-      CourierAssignmentModule couriers = warehouse.getModule(BuildingModules.WAREHOUSE_COURIERS);
-      int courierCount = couriers == null ? 0 : couriers.getAssignedCitizen().size();
-      if (courierCount <= 0) {
-        continue;
-      }
-      warehousesWithCouriers++;
       WarehouseRequestQueueModule queue =
-          warehouse.getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE);
+          entry.getValue().getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE);
       if (queue == null) {
         continue;
       }
@@ -423,56 +474,36 @@ final class CreateShopDeliveryManager {
       if (queue.getMutableRequestList().contains(token)) {
         if (Config.DEBUG_LOGGING.getAsBoolean()) {
           TheSettlerXCreate.LOGGER.info(
-              "[CreateShop] delivery enqueue token={} warehouse=<known> couriers={} queued=already",
-              token,
-              courierCount);
+              "[CreateShop] delivery warehouse queue token={} queued=present", token);
         }
         return true;
       }
-      queue.addRequest(token);
-      if (Config.DEBUG_LOGGING.getAsBoolean()) {
-        String warehouseInfo = "<unknown>";
-        try {
-          var getLocation = warehouse.getClass().getMethod("getLocation");
-          Object location = getLocation.invoke(warehouse);
-          if (location != null) {
-            warehouseInfo = location.toString();
-          }
-        } catch (Exception ignored) {
-          // Ignore reflection failures.
-        }
-        TheSettlerXCreate.LOGGER.info(
-            "[CreateShop] delivery enqueue token={} warehouse={} couriers={} queued=true",
-            token,
-            warehouseInfo,
-            courierCount);
-      }
-      return true;
     }
     if (Config.DEBUG_LOGGING.getAsBoolean()) {
       TheSettlerXCreate.LOGGER.info(
-          "[CreateShop] delivery enqueue token={} queued=false warehousesChecked={} withCouriers={} withQueue={}",
+          "[CreateShop] delivery warehouse queue token={} queued=missing buildingsChecked={} withQueue={}",
           token,
           warehousesChecked,
-          warehousesWithCouriers,
           warehousesWithQueue);
     }
     return false;
   }
 
-  private int notifyDeliverymen(IRequestManager manager, IToken<?> token) {
+  static int nudgeDeliverymen(IRequestManager manager, IToken<?> token) {
     if (manager == null || token == null) {
       return 0;
     }
-    int notified = 0;
+    int alreadyQueued = 0;
     int checked = 0;
+    int kicked = 0;
+    int warehousesWithToken = 0;
     var colony = manager.getColony();
     if (colony == null) {
-      return notified;
+      return 0;
     }
     var buildingManager = colony.getServerBuildingManager();
     if (buildingManager == null) {
-      return notified;
+      return 0;
     }
     for (var entry : buildingManager.getBuildings().entrySet()) {
       var building = entry.getValue();
@@ -483,36 +514,70 @@ final class CreateShopDeliveryManager {
         // Never treat the Create Shop worker as courier.
         continue;
       }
+      WarehouseRequestQueueModule queue =
+          building.getModule(BuildingModules.WAREHOUSE_REQUEST_QUEUE);
+      if (queue == null
+          || queue.getMutableRequestList() == null
+          || !queue.getMutableRequestList().contains(token)) {
+        continue;
+      }
+      warehousesWithToken++;
       CourierAssignmentModule warehouseCouriers =
           building.getModule(BuildingModules.WAREHOUSE_COURIERS);
-      if (warehouseCouriers != null) {
-        int count = notifyCourierModule(warehouseCouriers, token);
-        checked += count;
-        notified += count;
+      if (warehouseCouriers == null || warehouseCouriers.getAssignedCitizen() == null) {
+        continue;
       }
-      DeliverymanAssignmentModule deliverymanModule =
-          building.getModule(BuildingModules.COURIER_WORK);
-      if (deliverymanModule != null) {
-        int count = notifyCourierModule(deliverymanModule, token);
-        checked += count;
-        notified += count;
+      for (var citizen : warehouseCouriers.getAssignedCitizen()) {
+        if (citizen == null || !(citizen.getJob() instanceof JobDeliveryman job)) {
+          continue;
+        }
+        checked++;
+        if (job.getTaskQueue() != null && job.getTaskQueue().contains(token)) {
+          alreadyQueued++;
+          continue;
+        }
+
+        IRequest<?> currentTask;
+        try {
+          currentTask = job.getCurrentTask();
+        } catch (Exception ignored) {
+          currentTask = null;
+        }
+        if (job.getTaskQueue() != null && job.getTaskQueue().contains(token)) {
+          alreadyQueued++;
+          continue;
+        }
+        if (currentTask != null || !queue.getMutableRequestList().contains(token)) {
+          continue;
+        }
+
+        try {
+          job.addRequest(token, 0);
+          while (queue.getMutableRequestList().remove(token)) {
+            // Mirror MineColonies' native handoff: a courier-owned task leaves the warehouse queue.
+          }
+          queue.markDirty();
+          kicked++;
+        } catch (Exception e) {
+          if (Config.DEBUG_LOGGING.getAsBoolean()) {
+            TheSettlerXCreate.LOGGER.warn(
+                "[CreateShop] delivery courier handoff failed token={} citizen={}",
+                token,
+                citizen.getId(),
+                e);
+          }
+        }
       }
     }
     if (Config.DEBUG_LOGGING.getAsBoolean()) {
       TheSettlerXCreate.LOGGER.info(
-          "[CreateShop] delivery notify couriers token={} checked={} notified={}",
+          "[CreateShop] delivery nudge couriers token={} warehousesWithToken={} checked={} alreadyQueued={} kicked={}",
           token,
+          warehousesWithToken,
           checked,
-          notified);
+          alreadyQueued,
+          kicked);
     }
-    return notified;
-  }
-
-  private int notifyCourierModule(AbstractAssignedCitizenModule module, IToken<?> token) {
-    if (module == null) {
-      return 0;
-    }
-    var citizens = module.getAssignedCitizen();
-    return citizens == null ? 0 : citizens.size();
+    return alreadyQueued + kicked;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
@@ -15,7 +15,6 @@ import com.minecolonies.api.util.constant.TypeConstants;
 import com.minecolonies.core.colony.buildings.modules.BuildingModules;
 import com.minecolonies.core.colony.buildings.modules.CourierAssignmentModule;
 import com.minecolonies.core.colony.buildings.modules.WarehouseRequestQueueModule;
-import com.minecolonies.core.colony.jobs.JobDeliveryman;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
 import com.minecolonies.core.colony.requestsystem.resolvers.DeliveryRequestResolver;
 import com.minecolonies.core.colony.requestsystem.resolvers.core.AbstractWarehouseRequestResolver;
@@ -492,9 +491,8 @@ final class CreateShopDeliveryManager {
     if (manager == null || token == null) {
       return 0;
     }
-    int alreadyQueued = 0;
     int checked = 0;
-    int kicked = 0;
+    int availableCouriers = 0;
     int warehousesWithToken = 0;
     var colony = manager.getColony();
     if (colony == null) {
@@ -527,56 +525,21 @@ final class CreateShopDeliveryManager {
         continue;
       }
       for (var citizen : warehouseCouriers.getAssignedCitizen()) {
-        if (citizen == null || !(citizen.getJob() instanceof JobDeliveryman job)) {
+        if (citizen == null) {
           continue;
         }
         checked++;
-        if (job.getTaskQueue() != null && job.getTaskQueue().contains(token)) {
-          alreadyQueued++;
-          continue;
-        }
-
-        IRequest<?> currentTask;
-        try {
-          currentTask = job.getCurrentTask();
-        } catch (Exception ignored) {
-          currentTask = null;
-        }
-        if (job.getTaskQueue() != null && job.getTaskQueue().contains(token)) {
-          alreadyQueued++;
-          continue;
-        }
-        if (currentTask != null || !queue.getMutableRequestList().contains(token)) {
-          continue;
-        }
-
-        try {
-          job.addRequest(token, 0);
-          while (queue.getMutableRequestList().remove(token)) {
-            // Mirror MineColonies' native handoff: a courier-owned task leaves the warehouse queue.
-          }
-          queue.markDirty();
-          kicked++;
-        } catch (Exception e) {
-          if (Config.DEBUG_LOGGING.getAsBoolean()) {
-            TheSettlerXCreate.LOGGER.warn(
-                "[CreateShop] delivery courier handoff failed token={} citizen={}",
-                token,
-                citizen.getId(),
-                e);
-          }
-        }
+        availableCouriers++;
       }
     }
     if (Config.DEBUG_LOGGING.getAsBoolean()) {
       TheSettlerXCreate.LOGGER.info(
-          "[CreateShop] delivery nudge couriers token={} warehousesWithToken={} checked={} alreadyQueued={} kicked={}",
+          "[CreateShop] delivery nudge couriers token={} warehousesWithToken={} checked={} availableCouriers={}",
           token,
           warehousesWithToken,
           checked,
-          alreadyQueued,
-          kicked);
+          availableCouriers);
     }
-    return alreadyQueued + kicked;
+    return availableCouriers;
   }
 }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java
@@ -311,8 +311,7 @@ final class CreateShopDeliveryManager {
             continue;
           }
           BlockPos resolverPos = deliveryResolver.getLocation().getInDimensionLocation();
-          var building =
-              standard.getColony().getServerBuildingManager().getBuilding(resolverPos);
+          var building = standard.getColony().getServerBuildingManager().getBuilding(resolverPos);
           if (building instanceof BuildingCreateShop) {
             blacklist.add(resolverToken);
           }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryRootCauseSnapshotService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryRootCauseSnapshotService.java
@@ -94,7 +94,8 @@ final class CreateShopDeliveryRootCauseSnapshotService {
                 citizen.getJob() == null ? "<none>" : citizen.getJob().getClass().getSimpleName();
             String currentTask = "<none>";
             String taskQueue = "<na>";
-            if (citizen.getJob() instanceof com.minecolonies.core.colony.jobs.JobDeliveryman jobDeliveryman) {
+            if (citizen.getJob()
+                instanceof com.minecolonies.core.colony.jobs.JobDeliveryman jobDeliveryman) {
               try {
                 IRequest<?> task = jobDeliveryman.getCurrentTask();
                 currentTask = task == null ? "<none>" : String.valueOf(task.getId());
@@ -106,7 +107,10 @@ final class CreateShopDeliveryRootCauseSnapshotService {
                 taskQueue =
                     queueTokens == null
                         ? "<null>"
-                        : "size=" + queueTokens.size() + ",contains=" + queueTokens.contains(childToken);
+                        : "size="
+                            + queueTokens.size()
+                            + ",contains="
+                            + queueTokens.contains(childToken);
               } catch (Exception ignored) {
                 taskQueue = "<error>";
               }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryRootCauseSnapshotService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryRootCauseSnapshotService.java
@@ -92,6 +92,25 @@ final class CreateShopDeliveryRootCauseSnapshotService {
             String name = citizen.getName() == null ? "<unknown>" : citizen.getName();
             String job =
                 citizen.getJob() == null ? "<none>" : citizen.getJob().getClass().getSimpleName();
+            String currentTask = "<none>";
+            String taskQueue = "<na>";
+            if (citizen.getJob() instanceof com.minecolonies.core.colony.jobs.JobDeliveryman jobDeliveryman) {
+              try {
+                IRequest<?> task = jobDeliveryman.getCurrentTask();
+                currentTask = task == null ? "<none>" : String.valueOf(task.getId());
+              } catch (Exception ignored) {
+                currentTask = "<error>";
+              }
+              try {
+                var queueTokens = jobDeliveryman.getTaskQueue();
+                taskQueue =
+                    queueTokens == null
+                        ? "<null>"
+                        : "size=" + queueTokens.size() + ",contains=" + queueTokens.contains(childToken);
+              } catch (Exception ignored) {
+                taskQueue = "<error>";
+              }
+            }
             Object id;
             Object uuid;
             try {
@@ -114,6 +133,10 @@ final class CreateShopDeliveryRootCauseSnapshotService {
                     + job
                     + ",deliveryman="
                     + (citizen.getJob() instanceof com.minecolonies.core.colony.jobs.JobDeliveryman)
+                    + ",currentTask="
+                    + currentTask
+                    + ",taskQueue="
+                    + taskQueue
                     + "}");
           }
         }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolver.java
@@ -536,7 +536,7 @@ public class CreateShopRequestResolver extends AbstractWarehouseRequestResolver 
     lifecycleStateStore.getParentChildCompletedSeenAt().put(parentToken, tick);
   }
 
-  boolean hasParentChildCompletedSeen(IToken<?> parentToken) {
+  public boolean hasParentChildCompletedSeen(IToken<?> parentToken) {
     return parentToken != null
         && lifecycleStateStore.getParentChildCompletedSeenAt().containsKey(parentToken);
   }

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestValidator.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestValidator.java
@@ -113,7 +113,7 @@ final class CreateShopRequestValidator {
       return false;
     }
 
-    UUID requestId = resolver.toRequestId(request.getId());
+    UUID requestId = CreateShopRequestResolver.toRequestId(request.getId());
     int reservedForRequest = pickup.getReservedForRequest(requestId);
     int reservedForDeliverable = pickup.getReservedForDeliverable(deliverable);
     int reservedForOthers = Math.max(0, reservedForDeliverable - reservedForRequest);

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverRecheck.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopResolverRecheck.java
@@ -5,14 +5,12 @@ import com.minecolonies.core.colony.requestsystem.management.IStandardRequestMan
 import net.minecraft.world.level.Level;
 
 final class CreateShopResolverRecheck {
-  private final CreateShopRequestResolver resolver;
   private final CreateShopResolverDiagnostics diagnostics;
   private final java.util.Map<IToken<?>, Long> parentChildrenRecheck =
       new java.util.concurrent.ConcurrentHashMap<>();
 
   CreateShopResolverRecheck(
       CreateShopRequestResolver resolver, CreateShopResolverDiagnostics diagnostics) {
-    this.resolver = resolver;
     this.diagnostics = diagnostics;
   }
 

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRetryingReassignService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRetryingReassignService.java
@@ -62,7 +62,7 @@ final class CreateShopRetryingReassignService {
           continue;
         }
         if (request == null
-            || !(request.getRequest() instanceof IDeliverable deliverable)
+            || !(request.getRequest() instanceof IDeliverable)
             || request.getState()
                 == com.minecolonies.api.colony.requestsystem.request.RequestState.CANCELLED) {
           continue;

--- a/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopTerminalRequestLifecycleService.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopTerminalRequestLifecycleService.java
@@ -8,6 +8,8 @@ import com.minecolonies.api.colony.requestsystem.token.IToken;
 import com.minecolonies.core.colony.requestsystem.management.IStandardRequestManager;
 import com.thesettler_x_create.Config;
 import com.thesettler_x_create.TheSettlerXCreate;
+import com.thesettler_x_create.blockentity.CreateShopBlockEntity;
+import com.thesettler_x_create.minecolonies.building.BuildingCreateShop;
 import java.util.Collection;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
@@ -325,6 +327,21 @@ final class CreateShopTerminalRequestLifecycleService {
     var orphanChild = resolver.findPickedUpOrphanChildForParent(request.getId());
     if (orphanChild == null) {
       return false;
+    }
+    BuildingCreateShop shop = resolver.getShop(manager);
+    CreateShopBlockEntity pickup = shop == null ? null : shop.getPickupBlockEntity();
+    if (pickup != null) {
+      int reservedForRequest =
+          pickup.getReservedForRequest(CreateShopRequestResolver.toRequestId(request.getId()));
+      if (reservedForRequest > 0) {
+        if (isDebugLoggingEnabledSafe()) {
+          TheSettlerXCreate.LOGGER.info(
+              "[CreateShop] fast orphan picked-up recovery skipped parent={} reservationHeld={}",
+              request.getId(),
+              reservedForRequest);
+        }
+        return false;
+      }
     }
     Level level = manager.getColony() == null ? null : manager.getColony().getWorld();
     long nowTick = level == null ? 0L : level.getGameTime();

--- a/src/main/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShop.java
+++ b/src/main/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShop.java
@@ -317,6 +317,23 @@ public class TileEntityCreateShop extends AbstractTileEntityWareHouse {
     return false;
   }
 
+  /** Returns true when the hut-internal inventory contains items awaiting native pickup. */
+  public boolean hasHutInventoryItems() {
+    IItemHandler hut = getInventory();
+    if (hut == null) {
+      hut = getItemHandlerCap((Direction) null);
+    }
+    if (hut == null) {
+      return false;
+    }
+    for (int slot = 0; slot < hut.getSlots(); slot++) {
+      if (!hut.getStackInSlot(slot).isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Moves up to {@code maxStacks} unreserved rack stacks into hut inventory.
    *

--- a/src/main/resources/assets/thesettler_x_create/gui/layouthuts/layoutcreateshop_tasklist.xml
+++ b/src/main/resources/assets/thesettler_x_create/gui/layouthuts/layoutcreateshop_tasklist.xml
@@ -1,0 +1,17 @@
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/ldtteam/BlockUI/version/main/src/main/resources/assets/blockui/gui/block_ui.xsd"
+    size="190 244">
+    <image source="minecolonies:textures/gui/builderhut/builder_paper.png" size="190 244"/>
+    <text size="130 11" pos="30 14" color="black" textalign="MIDDLE"
+           label="$(com.minecolonies.coremod.gui.workerhuts.crafter.tasks)"/>
+
+    <list id="tasks" size="164 185" pos="13 29" emptytext="$(com.minecolonies.coremod.gui.workerhuts.crafter.tasks.empty)" emptycolor="black">
+        <box size="100% 34" linewidth="1">
+            <itemicon id="detailIcon" size="16 16" pos="1 3" visible="false"/>
+
+            <text id="shortDetail" size="130 9" pos="20 2" color="black"/>
+            <text id="priority" size="130 9" pos="20 12" color="black"/>
+
+            <text id="requester" size="150 9" pos="2 22" color="black"/>
+        </box>
+    </list>
+</window>

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingPickupRequestGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingPickupRequestGuardTest.java
@@ -1,0 +1,22 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BuildingCreateShopHousekeepingPickupRequestGuardTest {
+  @Test
+  void housekeepingCreatesNativePickupRequestAfterRackToHutMove() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
+
+    assertTrue(source.contains("if (moved > 0) {"));
+    assertTrue(source.contains("int pickupPriority = getPickUpPriority();"));
+    assertTrue(source.contains("boolean pickupRequested = createPickupRequest(pickupPriority);"));
+    assertTrue(source.contains("housekeeping pickup request priority={} created={} moved={}"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingPickupRequestGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingPickupRequestGuardTest.java
@@ -1,5 +1,6 @@
 package com.thesettler_x_create.minecolonies.building;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -8,15 +9,22 @@ import org.junit.jupiter.api.Test;
 
 class BuildingCreateShopHousekeepingPickupRequestGuardTest {
   @Test
-  void housekeepingCreatesNativePickupRequestAfterRackToHutMove() throws Exception {
+  void housekeepingCreatesNativePickupRequestForMovedOrExistingHutItems() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
 
-    assertTrue(source.contains("if (moved > 0) {"));
+    assertTrue(source.contains("boolean hutHasItems = tile.hasHutInventoryItems();"));
+    assertTrue(source.contains("if (moved > 0 || hutHasItems) {"));
     assertTrue(source.contains("int pickupPriority = getPickUpPriority();"));
-    assertTrue(source.contains("boolean pickupRequested = createPickupRequest(pickupPriority);"));
-    assertTrue(source.contains("housekeeping pickup request priority={} created={} moved={}"));
+    assertTrue(
+        source.contains("boolean pickupRequested = createNativeHutPickupRequest(pickupPriority);"));
+    assertTrue(source.contains("return createPickupRequest(pickupPriority);"));
+    assertTrue(
+        source.contains(
+            "housekeeping pickup request priority={} created={} moved={} hutHasItems={}"));
+    assertTrue(source.contains("source is the building requester's hut"));
+    assertFalse(source.contains("createHutInventoryPickupRequest"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingPickupRequestGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopHousekeepingPickupRequestGuardTest.java
@@ -20,7 +20,10 @@ class BuildingCreateShopHousekeepingPickupRequestGuardTest {
     assertTrue(source.contains("int pickupPriority = getPickUpPriority();"));
     assertTrue(
         source.contains("boolean pickupRequested = createNativeHutPickupRequest(pickupPriority);"));
-    assertTrue(source.contains("return createPickupRequest(pickupPriority);"));
+    assertTrue(
+        source.contains(
+            "Math.max(pickupPriority, AbstractDeliverymanRequestable.getPlayerActionPriority(false))"));
+    assertTrue(source.contains("return createPickupRequest(effectivePriority);"));
     assertTrue(
         source.contains(
             "housekeeping pickup request priority={} created={} moved={} hutHasItems={}"));

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopPickupRequestRecoveryGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopPickupRequestRecoveryGuardTest.java
@@ -1,0 +1,28 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class BuildingCreateShopPickupRequestRecoveryGuardTest {
+  @Test
+  void createShopRepairsStaleNativePickupRequestsBeforeCreatingNewOnes() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
+
+    assertTrue(source.contains("public boolean createPickupRequest(int pickupPriority)"));
+    assertTrue(source.contains("getOpenRequestsByRequestableType().get(TypeConstants.PICKUP)"));
+    assertTrue(source.contains("if (!(request.getRequest() instanceof Pickup))"));
+    assertTrue(source.contains("super.onRequestedRequestCancelled(standard, request);"));
+    assertTrue(source.contains("super.onRequestedRequestComplete(standard, request);"));
+    assertTrue(source.contains("manager.reassignRequest(token, Collections.emptyList());"));
+    assertTrue(source.contains("manager.assignRequest(token);"));
+    assertTrue(source.contains("resolver instanceof PickupRequestResolver"));
+    assertTrue(source.contains("pruneStalePickupRequestToken(token, \"missing-request\")"));
+    assertTrue(source.contains("return super.createPickupRequest(pickupPriority);"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopPickupRequestRecoveryGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopPickupRequestRecoveryGuardTest.java
@@ -22,6 +22,7 @@ class BuildingCreateShopPickupRequestRecoveryGuardTest {
     assertTrue(source.contains("manager.reassignRequest(token, Collections.emptyList());"));
     assertTrue(source.contains("manager.assignRequest(token);"));
     assertTrue(source.contains("resolver instanceof PickupRequestResolver"));
+    assertTrue(source.contains("pruneStalePickupRequestToken(token, \"lookup-failed\")"));
     assertTrue(source.contains("pruneStalePickupRequestToken(token, \"missing-request\")"));
     assertTrue(source.contains("return super.createPickupRequest(pickupPriority);"));
   }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopWarehouseAccessGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShopWarehouseAccessGuardTest.java
@@ -1,5 +1,6 @@
 package com.thesettler_x_create.minecolonies.building;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -8,12 +9,13 @@ import org.junit.jupiter.api.Test;
 
 class BuildingCreateShopWarehouseAccessGuardTest {
   @Test
-  void warehouseAccessUsesWarehouseDeliverymanRoleWithoutShopCourierModule() throws Exception {
+  void createShopDoesNotImplementWarehouseCourierContract() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/building/BuildingCreateShop.java"));
 
+    assertFalse(source.contains("implements IWareHouse"));
     assertTrue(source.contains("canAccessWareHouse(ICitizenData citizen)"));
     assertTrue(
         source.contains(

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopResolverFactoryDeliveryResolverGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopResolverFactoryDeliveryResolverGuardTest.java
@@ -1,0 +1,24 @@
+package com.thesettler_x_create.minecolonies.building;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ShopResolverFactoryDeliveryResolverGuardTest {
+  @Test
+  void createShopDoesNotRegisterLocalDeliverymenResolvers() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/building/ShopResolverFactory.java"));
+
+    assertTrue(source.contains("resolver instanceof DeliveryRequestResolver"));
+    assertTrue(source.contains("resolver instanceof PickupRequestResolver"));
+    assertTrue(source.contains("deliverymen resolvers skipped for CreateShop"));
+    assertFalse(source.contains("builder.add(new DeliveryRequestResolver"));
+    assertFalse(source.contains("builder.add(new PickupRequestResolver"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrarQueueModuleGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrarQueueModuleGuardTest.java
@@ -9,13 +9,16 @@ import org.junit.jupiter.api.Test;
 
 class ShopWarehouseRegistrarQueueModuleGuardTest {
   @Test
-  void warehouseRegistrationRequiresQueueModuleOnly() throws Exception {
+  void createShopIsRemovedFromWarehouseRegistration() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrar.java"));
 
-    assertTrue(source.contains("BuildingModules.WAREHOUSE_REQUEST_QUEUE"));
+    assertTrue(source.contains("warehouses.remove(shop)"));
+    assertTrue(source.contains("warehouseRegistered = false"));
+    assertFalse(source.contains("warehouses.add(shop)"));
+    assertFalse(source.contains("BuildingModules.WAREHOUSE_REQUEST_QUEUE"));
     assertFalse(source.contains("BuildingModules.WAREHOUSE_COURIERS"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrarQueueModuleGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrarQueueModuleGuardTest.java
@@ -15,7 +15,7 @@ class ShopWarehouseRegistrarQueueModuleGuardTest {
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/building/ShopWarehouseRegistrar.java"));
 
-    assertTrue(source.contains("warehouses.remove(shop)"));
+    assertTrue(source.contains("warehouses.removeIf(warehouse -> warehouse == shop)"));
     assertTrue(source.contains("warehouseRegistered = false"));
     assertFalse(source.contains("warehouses.add(shop)"));
     assertFalse(source.contains("BuildingModules.WAREHOUSE_REQUEST_QUEUE"));

--- a/src/test/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModuleInflightSerializationGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModuleInflightSerializationGuardTest.java
@@ -1,0 +1,22 @@
+package com.thesettler_x_create.minecolonies.module;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopTaskModuleInflightSerializationGuardTest {
+  @Test
+  void serializesQueueThenInflightTaskTokens() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java"));
+
+    assertTrue(source.contains("super.serializeToView(buf);"));
+    assertTrue(source.contains("List<IToken<?>> inflight = getInflightTaskTokens();"));
+    assertTrue(source.contains("buf.writeInt(inflight.size());"));
+    assertTrue(source.contains("StandardFactoryController.getInstance().serialize(buf, token);"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModuleInflightSerializationGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModuleInflightSerializationGuardTest.java
@@ -1,5 +1,6 @@
 package com.thesettler_x_create.minecolonies.module;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -18,5 +19,51 @@ class CreateShopTaskModuleInflightSerializationGuardTest {
     assertTrue(source.contains("List<IToken<?>> inflight = getInflightTaskTokens();"));
     assertTrue(source.contains("buf.writeInt(inflight.size());"));
     assertTrue(source.contains("StandardFactoryController.getInstance().serialize(buf, token);"));
+  }
+
+  @Test
+  void taskViewUsesCreateShopTaskWindow() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/moduleview/CreateShopTaskModuleView.java"));
+
+    assertTrue(source.contains("new CreateShopTaskModuleWindow(this)"));
+  }
+
+  @Test
+  void taskWindowUsesDisplayStacksAsIconFallback() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopTaskModuleWindow.java"));
+
+    assertTrue(source.contains("request.getDisplayStacks()"));
+    assertTrue(source.contains("detailIcon.setItem(stacks.get(0).copy())"));
+    assertTrue(source.contains("detailIcon.setVisible(true)"));
+    assertTrue(source.contains("layoutcreateshop_tasklist.xml"));
+  }
+
+  @Test
+  void taskWindowCollapsesDeliveryChildWhenParentInflightIsVisible() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/client/gui/CreateShopTaskModuleWindow.java"));
+
+    assertTrue(source.contains("isDeliveryChildHidden"));
+    assertTrue(source.contains("request.getRequest() instanceof Delivery"));
+    assertTrue(source.contains("allTokens.contains(request.getParent())"));
+  }
+
+  @Test
+  void taskLayoutUsesLeftItemIconInsteadOfDeliveryImage() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/resources/assets/thesettler_x_create/gui/layouthuts/layoutcreateshop_tasklist.xml"));
+
+    assertTrue(source.contains("<itemicon id=\"detailIcon\" size=\"16 16\" pos=\"1 3\""));
+    assertFalse(source.contains("deliveryImage"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModuleInflightVisibilityGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModuleInflightVisibilityGuardTest.java
@@ -1,0 +1,25 @@
+package com.thesettler_x_create.minecolonies.module;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopTaskModuleInflightVisibilityGuardTest {
+  @Test
+  void taskTabKeepsPreDeliveryInflightVisibleButHidesFinishedParentsWithoutChildren()
+      throws Exception {
+    String moduleSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/module/CreateShopTaskModule.java"));
+
+    assertTrue(
+        moduleSource.contains(
+            "if (resolver.hasParentChildCompletedSeen(token) && !request.hasChildren()) {"));
+    assertTrue(
+        moduleSource.contains(
+            "if (request.getState() != RequestState.IN_PROGRESS && !request.hasChildren()) {"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildingsTaskModuleGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildingsTaskModuleGuardTest.java
@@ -1,0 +1,21 @@
+package com.thesettler_x_create.minecolonies.registry;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ModMinecoloniesBuildingsTaskModuleGuardTest {
+  @Test
+  void createShopRegistersCustomWarehouseTaskModuleViewForInflightVisibility() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java"));
+
+    assertTrue(source.contains("\"warehouse_request_queue\""));
+    assertTrue(source.contains("CreateShopTaskModule::new"));
+    assertTrue(source.contains("CreateShopTaskModuleView::new"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildingsTaskModuleGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildingsTaskModuleGuardTest.java
@@ -1,5 +1,6 @@
 package com.thesettler_x_create.minecolonies.registry;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -14,7 +15,21 @@ class ModMinecoloniesBuildingsTaskModuleGuardTest {
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java"));
 
-    assertTrue(source.contains("\"warehouse_request_queue\""));
+    assertTrue(source.contains("\"createshop_request_queue\""));
+    assertTrue(source.contains("CreateShopTaskModule::new"));
+    assertTrue(source.contains("CreateShopTaskModuleView::new"));
+    assertTrue(source.contains("CreateShopTaskModule"));
+    assertTrue(source.contains("CreateShopTaskModuleView"));
+  }
+
+  @Test
+  void createShopDoesNotReregisterMineColoniesWarehouseQueueModuleId() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/registry/ModMinecoloniesBuildings.java"));
+
+    assertFalse(source.contains("\"warehouse_request_queue\""));
     assertTrue(source.contains("CreateShopTaskModule::new"));
     assertTrue(source.contains("CreateShopTaskModuleView::new"));
   }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionParentResolutionGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionParentResolutionGuardTest.java
@@ -1,0 +1,24 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopDeliveryCompletionParentResolutionGuardTest {
+  @Test
+  void deliveryCompletionResolvesParentWhenNoPendingRemainder() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java"));
+
+    assertTrue(source.contains("completeParentAfterDeliveredChild("));
+    assertTrue(source.contains("pending <= 0"));
+    assertTrue(source.contains("standard.updateRequestState(parentToken, RequestState.RESOLVED)"));
+    assertTrue(source.contains("detachCompletedChild("));
+    assertTrue(source.contains("hasActiveNonTerminalChild("));
+    assertTrue(source.contains("delivery-complete:parent-resolved"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionParentResolutionGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionParentResolutionGuardTest.java
@@ -15,7 +15,9 @@ class CreateShopDeliveryCompletionParentResolutionGuardTest {
                 "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java"));
 
     assertTrue(source.contains("completeParentAfterDeliveredChild("));
-    assertTrue(source.contains("pending <= 0"));
+    assertTrue(source.contains("computeOutstandingAfterDelivery("));
+    assertTrue(source.contains("outstandingNeededService.compute(parentRequest, deliverable"));
+    assertTrue(source.contains("Math.max(0, Math.max(trackedPending, outstanding)) > 0"));
     assertTrue(source.contains("standard.updateRequestState(parentToken, RequestState.RESOLVED)"));
     assertTrue(source.contains("detachCompletedChild("));
     assertTrue(source.contains("hasActiveNonTerminalChild("));

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerGuardTest.java
@@ -17,6 +17,20 @@ class CreateShopDeliveryLifecycleLedgerGuardTest {
     assertTrue(source.contains("MC_QUEUE_DEQUEUED_WITHOUT_TERMINAL"));
     assertTrue(source.contains("MC_NO_TERMINAL_CALLBACK"));
     assertTrue(source.contains("MC_HANDLER_LOST_TOKEN"));
+    assertTrue(source.contains("COURIER_QUEUE_HANDOFF_REPAIRED"));
+    assertTrue(source.contains("CreateShopDeliveryManager.nudgeDeliverymen(manager, childToken)"));
     assertTrue(source.contains("delivery-child-ledger source="));
+  }
+
+  @Test
+  void rootCauseSnapshotIncludesCourierJobState() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryRootCauseSnapshotService.java"));
+
+    assertTrue(source.contains("getCurrentTask()"));
+    assertTrue(source.contains("getTaskQueue()"));
+    assertTrue(source.contains("taskQueue="));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryLifecycleLedgerGuardTest.java
@@ -17,7 +17,7 @@ class CreateShopDeliveryLifecycleLedgerGuardTest {
     assertTrue(source.contains("MC_QUEUE_DEQUEUED_WITHOUT_TERMINAL"));
     assertTrue(source.contains("MC_NO_TERMINAL_CALLBACK"));
     assertTrue(source.contains("MC_HANDLER_LOST_TOKEN"));
-    assertTrue(source.contains("COURIER_QUEUE_HANDOFF_REPAIRED"));
+    assertTrue(source.contains("COURIER_QUEUE_HANDOFF_PENDING"));
     assertTrue(source.contains("CreateShopDeliveryManager.nudgeDeliverymen(manager, childToken)"));
     assertTrue(source.contains("delivery-child-ledger source="));
   }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerNotifyCountGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerNotifyCountGuardTest.java
@@ -8,13 +8,18 @@ import org.junit.jupiter.api.Test;
 
 class CreateShopDeliveryManagerNotifyCountGuardTest {
   @Test
-  void notifyDeliverymenTracksNotifiedCountFromModules() throws Exception {
+  void nudgeDeliverymenTracksNativeCourierHandoff() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java"));
 
-    assertTrue(source.contains("int notified = 0;"));
-    assertTrue(source.contains("notified += count;"));
+    assertTrue(source.contains("int alreadyQueued = 0;"));
+    assertTrue(source.contains("int kicked = 0;"));
+    assertTrue(source.contains("warehousesWithToken"));
+    assertTrue(source.contains("static int nudgeDeliverymen"));
+    assertTrue(source.contains("job.addRequest(token, 0);"));
+    assertTrue(source.contains("queue.getMutableRequestList().remove(token)"));
+    assertTrue(source.contains("assignDeliveryRequest(manager, token);"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerNotifyCountGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerNotifyCountGuardTest.java
@@ -8,18 +8,16 @@ import org.junit.jupiter.api.Test;
 
 class CreateShopDeliveryManagerNotifyCountGuardTest {
   @Test
-  void nudgeDeliverymenTracksNativeCourierHandoff() throws Exception {
+  void nudgeDeliverymenOnlyObservesNativeCourierAvailability() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java"));
 
-    assertTrue(source.contains("int alreadyQueued = 0;"));
-    assertTrue(source.contains("int kicked = 0;"));
+    assertTrue(source.contains("int availableCouriers = 0;"));
     assertTrue(source.contains("warehousesWithToken"));
     assertTrue(source.contains("static int nudgeDeliverymen"));
-    assertTrue(source.contains("job.addRequest(token, 0);"));
-    assertTrue(source.contains("queue.getMutableRequestList().remove(token)"));
+    assertTrue(source.contains("availableCouriers++;"));
     assertTrue(source.contains("assignDeliveryRequest(manager, token);"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerQueueOnlyDispatchGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerQueueOnlyDispatchGuardTest.java
@@ -18,8 +18,8 @@ class CreateShopDeliveryManagerQueueOnlyDispatchGuardTest {
     assertTrue(source.contains("assignDeliveryRequest(manager, token);"));
     assertTrue(source.contains("isQueuedInWarehouse(manager, token);"));
     assertFalse(source.contains("queue.addRequest(token)"));
-    assertTrue(source.contains("job.addRequest(token, 0);"));
-    assertTrue(source.contains("queue.getMutableRequestList().remove(token)"));
+    assertFalse(source.contains("job.addRequest(token, 0);"));
+    assertFalse(source.contains("queue.getMutableRequestList().remove(token)"));
     assertFalse(source.contains("shop.getModule(BuildingModules.WAREHOUSE_COURIERS)"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerQueueOnlyDispatchGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerQueueOnlyDispatchGuardTest.java
@@ -9,14 +9,17 @@ import org.junit.jupiter.api.Test;
 
 class CreateShopDeliveryManagerQueueOnlyDispatchGuardTest {
   @Test
-  void usesWarehouseQueueWithoutDirectJobInjectionAndDedupesQueue() throws Exception {
+  void usesNativeAssignmentWithWarehouseCourierHandoffOnly() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java"));
 
-    assertTrue(source.contains("queue.getMutableRequestList().contains(token)"));
-    assertFalse(source.contains("deliveryman.addRequest("));
+    assertTrue(source.contains("assignDeliveryRequest(manager, token);"));
+    assertTrue(source.contains("isQueuedInWarehouse(manager, token);"));
+    assertFalse(source.contains("queue.addRequest(token)"));
+    assertTrue(source.contains("job.addRequest(token, 0);"));
+    assertTrue(source.contains("queue.getMutableRequestList().remove(token)"));
     assertFalse(source.contains("shop.getModule(BuildingModules.WAREHOUSE_COURIERS)"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerRequesterBindingTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerRequesterBindingTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 
 class CreateShopDeliveryManagerRequesterBindingTest {
   @Test
-  void createsDeliveryChildWithNativeRequesterFallback() throws Exception {
+  void createsDeliveryChildWithCreateShopDisplayWrapperAroundNativeWarehouseRequester()
+      throws Exception {
     String source =
         Files.readString(
             Path.of(
@@ -16,10 +17,13 @@ class CreateShopDeliveryManagerRequesterBindingTest {
 
     assertTrue(
         source.contains(
-            "IRequester deliveryRequester = resolveDeliveryRequester(manager, request);"));
+            "IRequester deliveryRequester = resolveDeliveryRequester(manager, request, pickupLocation);"));
     assertTrue(source.contains("manager.createRequest(deliveryRequester, delivery)"));
+    assertTrue(source.contains("new CreateShopDeliveryRequester(requester, sourceLocation)"));
     assertTrue(source.contains("isWarehouseDeliveryResolver("));
     assertTrue(source.contains("candidate instanceof AbstractWarehouseRequestResolver"));
     assertTrue(source.contains("!(candidate instanceof CreateShopRequestResolver)"));
+    assertTrue(source.contains("getCreateShopDeliveryResolverBlacklist"));
+    assertTrue(source.contains("assignRequest(request, blacklist)"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerTest.java
@@ -47,7 +47,8 @@ class CreateShopDeliveryManagerTest {
   }
 
   @Test
-  void deliveryCreationPrefersRackPositionAsStartLocationForNormalShopDeliveries() throws Exception {
+  void deliveryCreationPrefersRackPositionAsStartLocationForNormalShopDeliveries()
+      throws Exception {
     String source =
         Files.readString(
             Path.of(

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.minecolonies.api.colony.requestsystem.location.ILocation;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import org.junit.jupiter.api.Test;
@@ -42,5 +44,17 @@ class CreateShopDeliveryManagerTest {
     assertFalse(
         CreateShopDeliveryManager.isSelfLoopDeliveryTarget(pickupLevel, null, targetLocation));
     assertFalse(CreateShopDeliveryManager.isSelfLoopDeliveryTarget(pickupLevel, startPos, null));
+  }
+
+  @Test
+  void deliveryCreationPrefersRackPositionAsStartLocationForNormalShopDeliveries() throws Exception {
+    String source =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java"));
+
+    assertTrue(source.contains("BlockPos startPos = pickup.getBlockPos();"));
+    assertTrue(source.contains("if (entry.getB() != null) {"));
+    assertTrue(source.contains("startPos = entry.getB();"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerWrappedFallbackGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManagerWrappedFallbackGuardTest.java
@@ -8,15 +8,16 @@ import org.junit.jupiter.api.Test;
 
 class CreateShopDeliveryManagerWrappedFallbackGuardTest {
   @Test
-  void wrappedManagerPathEnqueuesWhenNoResolverAssigned() throws Exception {
+  void wrappedManagerPathUsesNativeAssignmentWhenNoResolverAssigned() throws Exception {
     String source =
         Files.readString(
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryManager.java"));
 
-    assertTrue(source.contains("delivery native dispatch token={} viaWarehouseQueue={}"));
-    assertTrue(source.contains("resolveDeliveryRequester(manager, request)"));
+    assertTrue(source.contains("delivery native dispatch token={} assign={} warehouseQueue={}"));
+    assertTrue(source.contains("resolveDeliveryRequester(manager, request, pickupLocation)"));
     assertTrue(source.contains("manager.createRequest(deliveryRequester, delivery)"));
-    assertTrue(source.contains("tryEnqueueDelivery(manager, token)"));
+    assertTrue(source.contains("assignDeliveryRequest(manager, token)"));
+    assertTrue(source.contains("isQueuedInWarehouse(manager, token)"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryReservationHoldGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryReservationHoldGuardTest.java
@@ -1,0 +1,29 @@
+package com.thesettler_x_create.minecolonies.requestsystem.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CreateShopDeliveryReservationHoldGuardTest {
+  @Test
+  void keepsPickupReservationUntilTerminalDeliveryCleanup() throws Exception {
+    String reconciliationSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopChildReconciliationService.java"));
+    String completionSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopDeliveryCompletionService.java"));
+
+    assertFalse(reconciliationSource.contains("reservation release on courier pickup"));
+    assertFalse(reconciliationSource.contains("pickup.release(parentRequestId)"));
+    assertTrue(reconciliationSource.contains("held by reservation="));
+    assertTrue(
+        completionSource.contains(
+            "pickup.consumeReservedForRequest(parentRequestId, stack, stack.getCount())"));
+  }
+}

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverCallbacksTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverCallbacksTest.java
@@ -34,7 +34,8 @@ class CreateShopRequestResolverCallbacksTest {
 
     resolver.markDeliveriesCreated(parentToken);
 
-    IRequest<?> deliveryRequest = mock(IRequest.class);
+    @SuppressWarnings("unchecked")
+    IRequest<IDeliverable> deliveryRequest = (IRequest<IDeliverable>) mock(IRequest.class);
     when(deliveryRequest.getId()).thenReturn(deliveryToken);
     when(deliveryRequest.getParent()).thenReturn(parentToken);
     when(deliveryRequest.getRequest()).thenReturn(mock(IDeliverable.class));

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverFastOrphanRecoveryGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverFastOrphanRecoveryGuardTest.java
@@ -17,5 +17,7 @@ class CreateShopRequestResolverFastOrphanRecoveryGuardTest {
     assertTrue(source.contains("tryFastOrphanPickedUpRecovery(resolver, manager, request)"));
     assertTrue(source.contains("fast-orphan-pickedup-recovery"));
     assertTrue(source.contains("fast orphan picked-up recovery parent={} child={} -> resolved"));
+    assertTrue(source.contains("pickup.getReservedForRequest(CreateShopRequestResolver.toRequestId(request.getId()))"));
+    assertTrue(source.contains("fast orphan picked-up recovery skipped parent={} reservationHeld={}"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverFastOrphanRecoveryGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverFastOrphanRecoveryGuardTest.java
@@ -17,7 +17,10 @@ class CreateShopRequestResolverFastOrphanRecoveryGuardTest {
     assertTrue(source.contains("tryFastOrphanPickedUpRecovery(resolver, manager, request)"));
     assertTrue(source.contains("fast-orphan-pickedup-recovery"));
     assertTrue(source.contains("fast orphan picked-up recovery parent={} child={} -> resolved"));
-    assertTrue(source.contains("pickup.getReservedForRequest(CreateShopRequestResolver.toRequestId(request.getId()))"));
-    assertTrue(source.contains("fast orphan picked-up recovery skipped parent={} reservationHeld={}"));
+    assertTrue(
+        source.contains(
+            "pickup.getReservedForRequest(CreateShopRequestResolver.toRequestId(request.getId()))"));
+    assertTrue(
+        source.contains("fast orphan picked-up recovery skipped parent={} reservationHeld={}"));
   }
 }

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverLifecycleRuntimeTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverLifecycleRuntimeTest.java
@@ -48,6 +48,7 @@ class CreateShopRequestResolverLifecycleRuntimeTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   void recoverySkipsMutationWhenParentOwnershipDriftsAway() throws Exception {
     IToken<?> parentToken = token(UUID.randomUUID());
     IToken<?> childToken = token(UUID.randomUUID());
@@ -73,6 +74,7 @@ class CreateShopRequestResolverLifecycleRuntimeTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   void requestedCompleteCleansParentTrackingAndPendingState() throws Exception {
     IToken<?> parentToken = token(UUID.randomUUID());
     IToken<?> childToken = token(UUID.randomUUID());
@@ -91,7 +93,6 @@ class CreateShopRequestResolverLifecycleRuntimeTest {
     when(childRequest.getParent()).thenReturn(parentToken);
     when(manager.getRequestHandler().getRequest(childToken)).thenReturn((IRequest) childRequest);
 
-    @SuppressWarnings("unchecked")
     IRequest<IDeliverable> parentRequest = (IRequest<IDeliverable>) mock(IRequest.class);
     when(parentRequest.getId()).thenReturn(parentToken);
     when(parentRequest.getRequest()).thenReturn(mock(IDeliverable.class));
@@ -165,8 +166,9 @@ class CreateShopRequestResolverLifecycleRuntimeTest {
     return (Map<IToken<?>, Long>) mapField.get(store);
   }
 
+  @SuppressWarnings("unchecked")
   private IToken<?> token(UUID id) {
-    IToken<?> token = mock(IToken.class);
+    IToken<UUID> token = (IToken<UUID>) mock(IToken.class);
     when(token.getIdentifier()).thenReturn(id);
     when(token.toString()).thenReturn("token:" + id);
     return token;

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverTimeoutCleanupRuntimeTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverTimeoutCleanupRuntimeTest.java
@@ -44,12 +44,13 @@ class CreateShopRequestResolverTimeoutCleanupRuntimeTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   void timedOutFlowSkipsCleanupWhileDeliveryWindowIsActive() throws Exception {
     UUID parentId = UUID.randomUUID();
     IToken<?> parentToken = token(parentId);
     IToken<?> childToken = token(UUID.randomUUID());
 
-    IRequest<?> parentRequest = mock(IRequest.class);
+    IRequest<IDeliverable> parentRequest = (IRequest<IDeliverable>) mock(IRequest.class);
     when(parentRequest.getId()).thenReturn(parentToken);
     when(parentRequest.getRequest()).thenReturn(mock(IDeliverable.class));
     when(manager.getRequestHandler().getRequest(parentToken)).thenReturn((IRequest) parentRequest);
@@ -80,12 +81,13 @@ class CreateShopRequestResolverTimeoutCleanupRuntimeTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   void timedOutFlowReleasesReservationAndCleansTrackedStateWithoutActiveDeliveryWindow()
       throws Exception {
     UUID parentId = UUID.randomUUID();
     IToken<?> parentToken = token(parentId);
 
-    IRequest<?> parentRequest = mock(IRequest.class);
+    IRequest<IDeliverable> parentRequest = (IRequest<IDeliverable>) mock(IRequest.class);
     when(parentRequest.getId()).thenReturn(parentToken);
     when(parentRequest.getRequest()).thenReturn(mock(IDeliverable.class));
     when(parentRequest.hasChildren()).thenReturn(false);
@@ -143,8 +145,9 @@ class CreateShopRequestResolverTimeoutCleanupRuntimeTest {
     return (Map<IToken<?>, Long>) mapField.get(store);
   }
 
+  @SuppressWarnings("unchecked")
   private IToken<?> token(UUID id) {
-    IToken<?> token = mock(IToken.class);
+    IToken<UUID> token = (IToken<UUID>) mock(IToken.class);
     when(token.getIdentifier()).thenReturn(id);
     when(token.toString()).thenReturn("token:" + id);
     return token;

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverTwoPhaseStaleRecoveryRuntimeTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestResolverTwoPhaseStaleRecoveryRuntimeTest.java
@@ -137,8 +137,9 @@ class CreateShopRequestResolverTwoPhaseStaleRecoveryRuntimeTest {
     return (boolean) method.invoke(lifecycleService, args);
   }
 
+  @SuppressWarnings("unchecked")
   private IToken<?> token(UUID id) {
-    IToken<?> token = mock(IToken.class);
+    IToken<UUID> token = (IToken<UUID>) mock(IToken.class);
     when(token.getIdentifier()).thenReturn(id);
     when(token.toString()).thenReturn("token:" + id);
     return token;

--- a/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestStateMachineTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/requestsystem/resolver/CreateShopRequestStateMachineTest.java
@@ -72,8 +72,9 @@ class CreateShopRequestStateMachineTest {
     assertTrue(stateMachine.hasNonTerminalWork());
   }
 
+  @SuppressWarnings("unchecked")
   private IToken<?> token(String id) {
-    IToken<?> token = mock(IToken.class);
+    IToken<String> token = (IToken<String>) mock(IToken.class);
     when(token.getIdentifier()).thenReturn(id);
     when(token.toString()).thenReturn("token:" + id);
     return token;

--- a/src/test/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShopHousekeepingGuardTest.java
+++ b/src/test/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShopHousekeepingGuardTest.java
@@ -14,6 +14,7 @@ class TileEntityCreateShopHousekeepingGuardTest {
             Path.of(
                 "src/main/java/com/thesettler_x_create/minecolonies/tileentity/TileEntityCreateShop.java"));
     assertTrue(source.contains("hasUnreservedRackItems("));
+    assertTrue(source.contains("hasHutInventoryItems("));
     assertTrue(source.contains("moveUnreservedRackStacksToHut("));
     assertTrue(source.contains("collectRackBudgets("));
     assertTrue(source.contains("simulateInsertCount("));


### PR DESCRIPTION
## Summary
- adds a Create Shop task-tab module/view that shows local inflight parent requests alongside the native warehouse queue
- adds a custom Create Shop task-list window/layout for the existing MineColonies hut UI
- routes rack-to-hut housekeeping through MineColonies-native `createPickupRequest(...)` so couriers pick up from hut inventory instead of custom delivery paths
- adds serializable `CreateShopDeliveryRequester` support for Create Shop-sourced delivery children while preserving native warehouse requester delegation
- hardens delivery callback routing, requester binding, queue-only dispatch, notify accounting, reservation holds, and delivery-child lifecycle diagnostics
- fixes delivered Postbox orders staying open by resolving the original parent request after the terminal delivery child completes and no active child/pending remainder remains
- bumps the integration line to `0.2.0`
- updates provenance and feature status documentation for the new branch features and parent-completion fix
